### PR TITLE
Create a github action to re-genrate demo patients

### DIFF
--- a/.github/workflows/generate-demo-patients.yml
+++ b/.github/workflows/generate-demo-patients.yml
@@ -1,0 +1,106 @@
+name: Generate Demo Patients
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    env:
+      SIMULATION_PRESET: commit
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Delete existing dump
+        working-directory: src/test/resources
+        run: |
+          rm dump/dump.sql
+
+      - name: Start an OpenMRS instance
+        run: docker compose -f src/test/resources/docker-compose.yml up -d
+
+      # Setting up dependencies until the server starts to save time
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '15'
+
+      - name: Install dependencies
+        run: ./mvnw install -DskipTests
+
+      - name: Wait for the OpenMRS instance to start
+        run: while [[ "$(echo $(curl -s -o /dev/null -w '%{http_code}' http://localhost/openmrs/login.htm))" != "200" ]]; do echo "$(curl -i http://localhost/openmrs/login.htm)"; sleep 10; done
+
+      - name: Set the demo patient count
+        working-directory: src/test/resources
+        run: |
+          chmod +x set_demo_patient_count.sh
+          ./set_demo_patient_count.sh
+
+      - name: Restart the OpenMRS instance
+        run: docker compose -f src/test/resources/docker-compose.yml restart
+
+      - name: Wait for the OpenMRS instance to start and patients to be generated
+        run: while [[ "$(echo $(curl -s -o /dev/null -w '%{http_code}' http://localhost/openmrs/login.htm))" != "200" ]]; do echo "$(curl -i http://localhost/openmrs/login.htm)"; sleep 10; done
+
+      - name: Export a DB dump
+        working-directory: src/test/resources
+        run: |
+          chmod +x export_db_dump.sh
+          ./export_db_dump.sh
+
+      - name: Export Patient UUIDs
+        working-directory: src/test/resources
+        run: |
+          chmod +x export_patient_uuids.sh
+          ./export_patient_uuids.sh 
+
+      - name: Run performance tests
+        run: ./mvnw gatling:test
+
+      - name: Stop the OpenMRS instance
+        if: '!cancelled()'
+        run: docker stop $(docker ps -a -q)
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: report
+          path: target/gatling
+          retention-days: 30
+
+      # Publish the report to GH pages
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit the report to the report branch
+        working-directory: src/test/resources
+        run: |
+          git add dump
+          git add patient_uuids.csv
+          git commit -m "Regenerate demo patients"
+
+      - name: Push changes
+        run: |
+          git push origin main
+
+      - name: Capture Server Logs
+        if: always()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './logs'
+
+      - name: Upload Logs as Artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: server-logs
+          path: './logs'
+          retention-days: 2
+          overwrite: true

--- a/.github/workflows/generate-demo-patients.yml
+++ b/.github/workflows/generate-demo-patients.yml
@@ -7,7 +7,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     env:
-      SIMULATION_PRESET: commit
+      SIMULATION_PRESET: dev
+      TIER_DURATION_MINUTES: 5
+      USER_INCREMENT_PER_TIER: 32
+      TIER_COUNT: 6
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and easy-to-use framework for simulating user load and measuring system performa
 
 ### Prerequisites
 
-- Ensure you have OpenMRS running locally on port 80.
+- Ensure you have OpenMRS running locally on port 80. (Use the docker file: [src/test/resources/docker-compose.yml](src/test/resources/docker-compose.yml))
 - Java Development Kit (JDK) > 15 installed.
 - Apache Maven installed.
 
@@ -31,7 +31,7 @@ and easy-to-use framework for simulating user load and measuring system performa
 
 To run the performance tests locally, follow these steps:
 
-1. Start OpenMRS on port 80. (Use the docker file: [src/test/resources/docker-compose.yml](src/test/resources/docker-compose.yml) It contains demo patients for the test.)
+1. Start OpenMRS on port 80. (Use the docker file: [src/test/resources/docker-compose.yml](src/test/resources/docker-compose.yml) It contains demo patients for the test. [Learn more](#generating-demo-patient-data))
 2. Execute the following command in your terminal:
 
    **Standard** `export SIMULATION_PRESET='standard' && ./mvnw gatling:test` \
@@ -178,6 +178,68 @@ Add the following line to the `logback.xml` file in the `src/test/resources` dir
 
 <logger name="io.gatling.http.engine.response" level="DEBUG"/>
 ```
+
+
+## Generating Demo Patient Data
+
+Some scenarios require demo patients in the system, such as the "Visit Patient" scenario. There are several ways to achieve this:
+
+1. Create patients within the scenario.
+2. Create patients using the API before running tests.
+3. Leverage demo data generation.
+
+Option 3 was chosen because it helps generate patients with realistic data. Since this is a time-consuming task, the demo patients were pre-generated and saved as a database backup in the `src/test/resources/dump` directory. When you spin up the Docker container from the `src/test/resources/docker-compose.yml` file, the backup automatically loads into the database. Therefore, you don’t have to worry about generating and importing them manually.
+
+If you wish to regenerate patients with a fresh database, you can do so either manually or automatically in GitHub Actions.
+
+### To Generate Demo Patients Manually:
+
+1. Navigate to the resources directory:
+   ```bash
+   cd src/test/resources/
+   ```
+2. Delete the existing database dump file:
+   ```bash
+   rm dump/dump.sql
+   ```
+3. Stop and remove the existing Docker container:
+   ```bash
+   docker-compose down -v
+   ```
+4. Pull the newest image and spin up the Docker container:
+   ```bash
+   docker-compose pull
+   docker-compose up
+   ```
+5. Run the `set_demo_patient_count.sh` script to configure the `referencedemodata.createDemoPatientsOnNextStartup` global property. You can edit the patient count as needed:
+   ```bash
+   sh set_demo_patient_count.sh
+   ```
+6. Restart the Docker container and wait until all data is generated. Note that this is a time-consuming task:
+   ```bash
+   docker-compose restart
+   ```
+7. Export the patient UUIDs to a CSV file. This file will be used in `src/test/java/org/openmrs/performance/scenarios/VisitPatientScenario.java`:
+   ```bash
+   sh export_patient_uuids.sh
+   ```
+8. Take a database dump and replace the current one:
+   ```bash
+   sh export_db_dump.sh
+   ```
+
+### To Generate Demo Patients Automatically on GitHub:
+
+The process is automated with the following workflow:
+
+[Generate Demo Patients Workflow](https://github.com/openmrs/openmrs-contrib-performance-test/tree/main/.github/workflows/generate-demo-patients.yml)
+
+1. Visit the workflow page: [Generate Demo Patients Workflow](https://github.com/openmrs/openmrs-contrib-performance-test/actions/workflows/generate-demo-patients.yml).
+2. Click the "Run Workflow" button.
+
+This process may take approximately 4 hours to complete and will automatically commit the database dump and patient UUIDs to the repository.
+
+
 
 ## Additional Resources
 

--- a/src/test/resources/set_demo_patient_count.sh
+++ b/src/test/resources/set_demo_patient_count.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# MySQL credentials
+DB_USER="openmrs"
+DB_PASS="openmrs"
+DB_NAME="openmrs"
+DB_PORT="3306"
+DB_HOST="127.0.0.1"
+PATIENT_COUNT=200
+
+# Query to be executed
+QUERY="UPDATE global_property SET property_value=$PATIENT_COUNT WHERE property='referencedemodata.createDemoPatientsOnNextStartup';"
+
+# Inform about the process and count
+echo "Running SQL query to update 'referencedemodata.createDemoPatientsOnNextStartup' property_value to $PATIENT_COUNT"
+echo "Expected patient count: $PATIENT_COUNT"
+
+# Execute the SQL query
+result=$(mysql -u$DB_USER -p$DB_PASS -D$DB_NAME -P$DB_PORT -h$DB_HOST -e "$QUERY" 2>&1)
+
+# Print the result of the query execution
+if [ $? -eq 0 ]; then
+    echo "Query executed successfully."
+else
+    echo "Error executing query: $result"
+fi


### PR DESCRIPTION
The purpose of this PR is to generate patient data with github. I converted the following manual process to a github workflow:

1. Navigate to the resources directory:
   ```bash
   cd src/test/resources/
   ```
2. Delete the existing database dump file:
   ```bash
   rm dump/dump.sql
   ```
3. Stop and remove the existing Docker container:
   ```bash
   docker-compose down -v
   ```
4. Pull the newest image and spin up the Docker container:
   ```bash
   docker-compose pull
   docker-compose up
   ```
5. Run the `set_demo_patient_count.sh` script to configure the `referencedemodata.createDemoPatientsOnNextStartup` global property. You can edit the patient count as needed:
   ```bash
   sh set_demo_patient_count.sh
   ```
6. Restart the Docker container and wait until all data is generated. Note that this is a time-consuming task:
   ```bash
   docker-compose restart
   ```
7. Export the patient UUIDs to a CSV file. This file will be used in `src/test/java/org/openmrs/performance/scenarios/VisitPatientScenario.java`:
   ```bash
   sh export_patient_uuids.sh
   ```
8. Take a database dump and replace the current one:
   ```bash
   sh export_db_dump.sh
   ```