### PR TITLE
O3-4402: Remove conditional checks in published task

### DIFF
--- a/.github/workflows/run-tests-on-gh.yml
+++ b/.github/workflows/run-tests-on-gh.yml
@@ -43,8 +43,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Update the load configuration for PRS
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Changes Implemented:

- Updated the workflow file to ensure the steps for pushing the report always run, regardless of test outcomes.
- Added a conditional check to execute the report push step only if the workflow is triggered by a schedule or dispatch event.

ticket - https://openmrs.atlassian.net/browse/O3-4402