### PR TITLE
O3-4528: Separate save vitals action

### DIFF
--- a/src/test/java/org/openmrs/performance/registries/DoctorRegistry.java
+++ b/src/test/java/org/openmrs/performance/registries/DoctorRegistry.java
@@ -73,8 +73,11 @@ public class DoctorRegistry extends Registry<DoctorHttpService>{
 				MID_UPPER_ARM_CIRCUMFERENCE
 		);
 		return exec(httpService.getPatientObservations(patientUuid, vitals))
-				.exec(httpService.getPatientObservations(patientUuid, biometrics))
-				.exec(httpService.saveVitalsData(patientUuid));
+				.exec(httpService.getPatientObservations(patientUuid, biometrics));
+	}
+
+	public ChainBuilder saveVitals(String patientUuid){
+		return exec(httpService.saveVitalsData(patientUuid));
 	}
 	
 	public ChainBuilder openMedicationsTab(String patientUuid) {

--- a/src/test/java/org/openmrs/performance/registries/DoctorRegistry.java
+++ b/src/test/java/org/openmrs/performance/registries/DoctorRegistry.java
@@ -76,7 +76,7 @@ public class DoctorRegistry extends Registry<DoctorHttpService>{
 				.exec(httpService.getPatientObservations(patientUuid, biometrics));
 	}
 
-	public ChainBuilder saveVitals(String patientUuid){
+	public ChainBuilder recordVitals(String patientUuid){
 		return exec(httpService.saveVitalsData(patientUuid));
 	}
 	

--- a/src/test/java/org/openmrs/performance/scenarios/VisitPatientScenario.java
+++ b/src/test/java/org/openmrs/performance/scenarios/VisitPatientScenario.java
@@ -30,7 +30,7 @@ public class VisitPatientScenario extends Scenario<DoctorRegistry> {
 				.pause(2)
 				.exec(registry.openVitalsAndBiometricsTab("#{patient_uuid}"))
 				.pause(5)
-				.exec(registry.saveVitals("#{patient_uuid}"))
+				.exec(registry.recordVitals("#{patient_uuid}"))
 				.pause(5)
 				.exec(registry.openMedicationsTab("#{patient_uuid}"))
 				.pause(5)

--- a/src/test/java/org/openmrs/performance/scenarios/VisitPatientScenario.java
+++ b/src/test/java/org/openmrs/performance/scenarios/VisitPatientScenario.java
@@ -30,6 +30,8 @@ public class VisitPatientScenario extends Scenario<DoctorRegistry> {
 				.pause(2)
 				.exec(registry.openVitalsAndBiometricsTab("#{patient_uuid}"))
 				.pause(5)
+				.exec(registry.saveVitals("#{patient_uuid}"))
+				.pause(5)
 				.exec(registry.openMedicationsTab("#{patient_uuid}"))
 				.pause(5)
 				.exec(registry.openOrdersTab("#{patient_uuid}"))


### PR DESCRIPTION
This PR separates the Vitals Save functionality from openVitalsAndBiometricsTab into a dedicated function.

Ticket URL - https://openmrs.atlassian.net/browse/O3-4528

