### PR TITLE
O3 4770: Fix the GetDrugOrders end points

### DIFF
--- a/src/test/java/org/openmrs/performance/http/DoctorHttpService.java
+++ b/src/test/java/org/openmrs/performance/http/DoctorHttpService.java
@@ -151,7 +151,7 @@ public class DoctorHttpService extends HttpService {
 		        + "encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,"
 		        + "orderType,urgency,instructions,commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid)"
 		        + ",concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,"
-		        + "numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)" ;
+		        + "numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)";
 
 		return http("Get Drug Orders except the cancelled and expired").get(
 		    "/openmrs/ws/rest/v1/order" + "?patient=" + patientUuid + "&careSetting=" + CARE_SETTING_UUID
@@ -160,11 +160,11 @@ public class DoctorHttpService extends HttpService {
 
 	public HttpRequestActionBuilder getDrugOrdersExceptDiscontinuedOrders(String patientUuid) {
 		String customRepresentation = "custom:(uuid,dosingType,orderNumber,accessionNumber,patient:ref,action,"
-		         + "careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,"
+		        + "careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,"
 		        + "orderType:ref,encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,"
 		        + "orderType,urgency,instructions,commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid),"
 		        + "concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,"
-		        + "numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)" ;
+		        + "numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)";
 
 		return http("Get Drug Orders except the discontinued orders").get("/openmrs/ws/rest/v1/order" + "?patient="
 		        + patientUuid + "&careSetting=" + CARE_SETTING_UUID + "&status=any&orderType=" + DRUG_ORDER + "&v="

--- a/src/test/java/org/openmrs/performance/http/DoctorHttpService.java
+++ b/src/test/java/org/openmrs/performance/http/DoctorHttpService.java
@@ -146,28 +146,26 @@ public class DoctorHttpService extends HttpService {
 	}
 
 	public HttpRequestActionBuilder getDrugOrdersExceptCancelledAndExpired(String patientUuid) {
-		String customRepresentation = """
-		        custom:(uuid,dosingType,orderNumber,accessionNumber,patient:ref,action,careSetting:ref,
-		        previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,orderType:ref,
-		        encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,
-		        orderType,urgency,instructions,commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid),concept),
-		        dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,
-		        numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)
-		        """;
+		String customRepresentation = "custom:(uuid,dosingType,orderNumber,accessionNumber,patient:ref,action,careSetting"
+		        + ":ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,orderType:ref,"
+		        + "encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,"
+		        + "orderType,urgency,instructions,commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid)"
+		        + ",concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,"
+		        + "numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)" ;
+
 		return http("Get Drug Orders except the cancelled and expired").get(
 		    "/openmrs/ws/rest/v1/order" + "?patient=" + patientUuid + "&careSetting=" + CARE_SETTING_UUID
 		            + "&status=any&orderType=" + DRUG_ORDER + "&excludeCanceledAndExpired=true&v=" + customRepresentation);
 	}
 
 	public HttpRequestActionBuilder getDrugOrdersExceptDiscontinuedOrders(String patientUuid) {
-		String customRepresentation = """
-		        custom:(uuid,dosingType,orderNumber,accessionNumber,patient:ref,action,careSetting:ref,
-		        previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,orderType:ref,
-		        encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,
-		        orderType,urgency,instructions,commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid),concept),
-		        dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,
-		        numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)
-		        """;
+		String customRepresentation = "custom:(uuid,dosingType,orderNumber,accessionNumber,patient:ref,action,"
+		         + "careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,"
+		        + "orderType:ref,encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,"
+		        + "orderType,urgency,instructions,commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid),"
+		        + "concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,"
+		        + "numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)" ;
+
 		return http("Get Drug Orders except the discontinued orders").get("/openmrs/ws/rest/v1/order" + "?patient="
 		        + patientUuid + "&careSetting=" + CARE_SETTING_UUID + "&status=any&orderType=" + DRUG_ORDER + "&v="
 		        + customRepresentation + "&excludeDiscontinueOrders=true");
@@ -260,11 +258,7 @@ public class DoctorHttpService extends HttpService {
 	}
 
 	public HttpRequestActionBuilder searchForDrug(String searchQuery) {
-		String customRepresentation = """
-		        custom:(uuid,display,name,strength,
-		        	dosageForm:(display,uuid),
-		        	concept:(display,uuid))
-		        """;
+		String customRepresentation = "custom:(uuid,display,name,strength,dosageForm:(display,uuid),concept:(display,uuid))";
 		return http("Search for Drug").get("/openmrs/ws/rest/v1/drug?name=" + searchQuery + "&v=" + customRepresentation);
 	}
 


### PR DESCRIPTION
This PR is responsible to remove multiline string literal. The GetDrugOrders are failing , cause the custom string is represented as a string literal is adding the \n (new line ) into the URL leading to its failure.