### PR TITLE
O3-4787: Rectifying the issue with the submit visit form

### DIFF
--- a/src/test/java/org/openmrs/performance/http/DoctorHttpService.java
+++ b/src/test/java/org/openmrs/performance/http/DoctorHttpService.java
@@ -101,11 +101,10 @@ public class DoctorHttpService extends HttpService {
 	}
 
 	public HttpRequestActionBuilder submitVisitForm(String patientUuid, String visitTypeUuid, String locationUuid) {
-		String startDateTime = CommonUtils.getCurrentDateTimeAsString();
 
 		Map<String, String> requestBodyMap = new HashMap<>();
 		requestBodyMap.put("patient", patientUuid);
-		requestBodyMap.put("startDatetime", startDateTime);
+		requestBodyMap.put("startDatetime", null);
 		requestBodyMap.put("visitType", visitTypeUuid);
 		requestBodyMap.put("location", locationUuid);
 
@@ -120,20 +119,17 @@ public class DoctorHttpService extends HttpService {
 	}
 
 	public HttpRequestActionBuilder submitEndVisit(String visitUuid, String locationUuid, String visitTypeUuid) {
-		String formattedStopDateTime = CommonUtils.getCurrentDateTimeAsString();
 
-		Map<String, String> requestBodyMap = new HashMap<>();
-		requestBodyMap.put("location", locationUuid);
-		requestBodyMap.put("visitType", visitTypeUuid);
-		requestBodyMap.put("stopDatetime", formattedStopDateTime);
-
-		try {
-			return http("End Visit").post("/openmrs/ws/rest/v1/visit/" + visitUuid)
-			        .body(StringBody(new ObjectMapper().writeValueAsString(requestBodyMap)));
-		}
-		catch (JsonProcessingException e) {
-			throw new RuntimeException(e);
-		}
+		return http("End Visit").post("/openmrs/ws/rest/v1/visit/" + visitUuid).body(StringBody(session -> {
+			try {
+				Map<String, String> requestBodyMap = new HashMap<>();
+				requestBodyMap.put("stopDatetime", CommonUtils.getCurrentDateTimeAsString());
+				return new ObjectMapper().writeValueAsString(requestBodyMap);
+			}
+			catch (JsonProcessingException e) {
+				throw new RuntimeException(e);
+			}
+		}));
 	}
 
 	public HttpRequestActionBuilder getOrderTypes() {


### PR DESCRIPTION
This PR is to deal with the failure of the start visit form, 

Issue:
The Submit Visit form was failing after cycling through all newly created users. The root cause was traced to the static generation of startTime and endTime values within the HTTP request builder. These timestamps were generated only once—at compile time—resulting in identical values for all visits. Consequently, when the same patient was encountered again, the system detected a duplicate visit due to identical timestamps and threw an “already exists” error.

Solution:
To resolve this, a session function has been implemented within the body of the POST request to dynamically generate startTime and endTime for each submission. This ensures each visit entry has unique timestamps, preventing conflicts and enabling multiple submissions across different users without errors

TICKET:  https://openmrs.atlassian.net/browse/O3-4787
