### PR TITLE
O3-4835: Modification of the conifg file

### DIFF
--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -81,7 +81,7 @@ gatling {
     #perUserCacheMaxCapacity = 200           # Per virtual user cache size, set to 0 to disable
     #warmUpUrl = "https://gatling.io"        # The URL to use to warm-up the HTTP stack (blank means disabled)
     #pooledConnectionIdleTimeout = 60000     # Timeout in millis for a connection to stay idle in the pool
-    #requestTimeout = 60000                  # Timeout in millis for performing an HTTP request
+    requestTimeout = 180000                  # Timeout in millis for performing an HTTP request
     #enableHostnameVerification = false      # When set to true, enable hostname verification: SSLEngine.setHttpsEndpointIdentificationAlgorithm("HTTPS")
     dns {
       #queryTimeout = 5000                   # Timeout in millis of each DNS query in millis


### PR DESCRIPTION
The current test are failing cause of a 60000 ms timeout , thus this PR is created to extend the timeout to 180000ms.

Ticket: https://openmrs.atlassian.net/browse/O3-4835