### PR TITLE
O3-4953: Create a response size logs table

### DIFF
--- a/commit-report.sh
+++ b/commit-report.sh
@@ -3,7 +3,7 @@ set -e
 
 # Delete everything except the target directory
 shopt -s extglob
-rm -rf !(target|performance-trends)
+rm -rf !(target|performance-trends|response-sizes)
 
 # Identify the directory starting with test-simulation- inside target/gatling/
 report=$(find target/gatling -maxdepth 1 -type d -name "openmrsclinic-*" | head -n 1)

--- a/response-sizes/app.js
+++ b/response-sizes/app.js
@@ -1,0 +1,211 @@
+let tableData = [];
+let currentSort = {
+    columnKey: null,
+    direction: 'asc'
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadReport();
+});
+
+async function loadReport() {
+    const reportContainer = document.getElementById('reportContainer');
+    const csvFilePath = 'response_sizes.csv'; // Or your correct path
+
+    try {
+        const response = await fetch(csvFilePath);
+        if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}. Could not find or access '${csvFilePath}'.`);
+        }
+        const text = await response.text();
+        const data = parseCSV(text);
+        if (data.length === 0) {
+            throw new Error("CSV file is empty or could not be parsed.");
+        }
+
+        // Store the calculated stats globally
+        tableData = calculateStatistics(data);
+        // Initial display of the report
+        displayReport(tableData);
+
+    } catch (error) {
+        console.error('Failed to load report:', error);
+        reportContainer.innerHTML = `<div class="error-message">...</div>`; // Your existing error handling
+    }
+}
+
+function displayReport(stats) {
+    const reportContainer = document.getElementById('reportContainer');
+    reportContainer.innerHTML = ''; // Clear loading message
+
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    const tbody = document.createElement('tbody');
+    tbody.id = 'report-tbody'; // Give tbody an ID for easy access
+
+    const headerConfig = [
+        { text: 'Request Name', key: 'name', type: 'string' },
+        { text: 'Total Requests', key: 'count', type: 'number' },
+        { text: 'Min', key: 'min', type: 'number' },
+        { text: 'Max', key: 'max', type: 'number' },
+        { text: 'Median (P50)', key: 'p50', type: 'number' },
+        { text: 'P75', key: 'p75', type: 'number' },
+        { text: 'P95', key: 'p95', type: 'number' },
+        { text: 'P99', key: 'p99', type: 'number' }
+    ];
+
+    const headerRow = document.createElement('tr');
+    headerConfig.forEach(config => {
+        const th = document.createElement('th');
+        th.textContent = config.text;
+        th.dataset.key = config.key; // Store the key for sorting
+        th.dataset.type = config.type; // Store the data type
+        th.classList.add('sortable'); // Add class to apply sorting styles
+
+        // Add click event listener to each header
+        th.addEventListener('click', () => {
+            sortTable(config.key, config.type);
+        });
+
+        headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+
+    table.appendChild(thead);
+    table.appendChild(tbody); // Append empty tbody
+    reportContainer.appendChild(table);
+
+    renderTableBody(stats); // Render the initial data
+    updateHeaderStyles(); // Set initial header styles
+}
+
+function sortTable(key, type) {
+    // Determine sort direction
+    if (currentSort.columnKey === key) {
+        currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc';
+    } else {
+        currentSort.columnKey = key;
+        currentSort.direction = 'asc';
+    }
+
+    // Sort the global data array
+    tableData.sort((a, b) => {
+        const valA = a[key];
+        const valB = b[key];
+        let comparison = 0;
+
+        if (type === 'string') {
+            comparison = valA.localeCompare(valB);
+        } else { // type === 'number'
+            comparison = valA - valB;
+        }
+
+        return comparison * (currentSort.direction === 'asc' ? 1 : -1);
+    });
+
+    // Re-render the table body with sorted data
+    renderTableBody(tableData);
+    // Update the header styles to show the sort arrow
+    updateHeaderStyles();
+}
+
+function renderTableBody(stats) {
+    const tbody = document.getElementById('report-tbody');
+    tbody.innerHTML = ''; // Clear existing rows
+
+    stats.forEach(stat => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td class="text-left">${stat.name}</td>
+            <td class="text-right">${stat.count}</td>
+            <td class="text-right">${stat.min}</td>
+            <td class="text-right">${stat.max}</td>
+            <td class="text-right">${stat.p50}</td>
+            <td class="text-right">${stat.p75}</td>
+            <td class="text-right">${stat.p95}</td>
+            <td class="text-right">${stat.p99}</td>
+        `;
+        tbody.appendChild(row);
+    });
+}
+
+function updateHeaderStyles() {
+    document.querySelectorAll('#reportContainer th.sortable').forEach(th => {
+        th.classList.remove('sorted-asc', 'sorted-desc');
+        if (th.dataset.key === currentSort.columnKey) {
+            th.classList.add(currentSort.direction === 'asc' ? 'sorted-asc' : 'sorted-desc');
+        }
+    });
+}
+
+// --- Your existing helper functions (no changes needed) ---
+function parseCSV(text) { /* ... same as before ... */ }
+function calculateStatistics(data) { /* ... same as before ... */ }
+function calculatePercentile(sortedArr, percentile) { /* ... same as before ... */ }
+
+// --- PASTE YOUR EXISTING HELPER FUNCTIONS HERE ---
+// To keep this block clean, I've omitted them, but you should
+// ensure parseCSV, calculateStatistics, and calculatePercentile are still here.
+function parseCSV(text) {
+    const lines = text.trim().split(/\r?\n/);
+    if (lines.length < 2) return [];
+
+    const headers = lines[0].split(',');
+    const records = [];
+
+    for (let i = 1; i < lines.length; i++) {
+        const values = lines[i].split(',');
+        if (values.length === headers.length) {
+            let record = {};
+            headers.forEach((header, index) => {
+                const value = values[index].replace(/"/g, '').trim();
+                record[header.trim()] = value;
+            });
+            records.push(record);
+        }
+    }
+    return records;
+}
+
+function calculateStatistics(data) {
+    const groups = data.reduce((acc, record) => {
+        const name = record.RequestName;
+        const size = parseInt(record['ResponseSize(Bytes)'], 10);
+
+        if (!name || isNaN(size)) return acc;
+
+        if (!acc[name]) {
+            acc[name] = [];
+        }
+        acc[name].push(size);
+        return acc;
+    }, {});
+
+    const results = [];
+    for (const name in groups) {
+        const sizes = groups[name].sort((a, b) => a - b);
+        results.push({
+            name: name,
+            count: sizes.length,
+            min: sizes[0],
+            max: sizes[sizes.length - 1],
+            p50: calculatePercentile(sizes, 50),
+            p75: calculatePercentile(sizes, 75),
+            p95: calculatePercentile(sizes, 95),
+            p99: calculatePercentile(sizes, 99),
+        });
+    }
+    return results.sort((a, b) => a.name.localeCompare(b.name)); // Initial sort by name
+}
+
+function calculatePercentile(sortedArr, percentile) {
+    if (sortedArr.length === 0) return 0;
+    const index = (percentile / 100) * (sortedArr.length - 1);
+    const lower = Math.floor(index);
+    const upper = Math.ceil(index);
+
+    if (lower === upper) {
+        return sortedArr[index];
+    }
+    return Math.round(sortedArr[lower] * (upper - index) + sortedArr[upper] * (index - lower));
+}

--- a/response-sizes/index.html
+++ b/response-sizes/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Performance Log Report (Dark)</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header>
+    <h1>Performance Response Size Report</h1>
+</header>
+
+<main>
+    <div id="reportContainer">
+        <p id="loadingMessage">Loading report data from <code>response_sizes.csv</code>...</p>
+    </div>
+</main>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/response-sizes/response_sizes.csv
+++ b/response-sizes/response_sizes.csv
@@ -1,0 +1,2596 @@
+Timestamp,RequestName,ResponseSize(Bytes)
+2025-08-08T17:56:51.498713Z,"Login",1140
+2025-08-08T17:56:51.499754Z,"Login",1140
+2025-08-08T17:56:51.499787Z,"Login",1140
+2025-08-08T17:56:52.569499Z,"Get locations",41279
+2025-08-08T17:56:52.569745Z,"Get locations",41279
+2025-08-08T17:56:52.569958Z,"Get locations",41279
+2025-08-08T17:56:57.588984Z,"Select Location",1140
+2025-08-08T17:56:57.589188Z,"Select Location",1140
+2025-08-08T17:56:57.589246Z,"Select Location",1140
+2025-08-08T17:56:57.598802Z,"Get Address Template",1428
+2025-08-08T17:56:57.599266Z,"Get Address Template",1428
+2025-08-08T17:56:57.599376Z,"Get Address Template",1428
+2025-08-08T17:56:57.614834Z,"Get Relationship Types",5960
+2025-08-08T17:56:57.614931Z,"Get Relationship Types",5960
+2025-08-08T17:56:57.614973Z,"Get Relationship Types",5960
+2025-08-08T17:56:57.637010Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:56:57.637127Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:56:57.637568Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:56:57.640899Z,"Get Module Information",1237
+2025-08-08T17:56:57.640999Z,"Get Module Information",1237
+2025-08-08T17:56:57.641043Z,"Get Module Information",1237
+2025-08-08T17:56:57.646528Z,"Get Patient Identifier Types",971
+2025-08-08T17:56:57.646629Z,"Get Patient Identifier Types",971
+2025-08-08T17:56:57.646667Z,"Get Patient Identifier Types",971
+2025-08-08T17:56:57.651534Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:56:57.651616Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:56:57.651657Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:56:57.656692Z,"Get Identifier Source",1233
+2025-08-08T17:56:57.656760Z,"Get Identifier Source",1233
+2025-08-08T17:56:57.656797Z,"Get Identifier Source",1233
+2025-08-08T17:56:57.666073Z,"Get Locations by Tag and Query",233
+2025-08-08T17:56:57.666234Z,"Get Locations by Tag and Query",233
+2025-08-08T17:56:57.666313Z,"Get Locations by Tag and Query",233
+2025-08-08T17:56:57.671976Z,"Get Visits",29
+2025-08-08T17:56:57.672050Z,"Get Visits",29
+2025-08-08T17:56:57.672155Z,"Get Visits",29
+2025-08-08T17:56:57.678930Z,"Get Auto Generation Options",2298
+2025-08-08T17:56:57.679027Z,"Get Auto Generation Options",2298
+2025-08-08T17:56:57.679072Z,"Get Auto Generation Options",2298
+2025-08-08T17:56:57.686765Z,"Get Identifier Source",0
+2025-08-08T17:56:57.686962Z,"Get Identifier Source",0
+2025-08-08T17:56:57.687113Z,"Get Identifier Source",0
+2025-08-08T17:56:57.698330Z,"Get Queue Entry",29
+2025-08-08T17:56:57.698418Z,"Get Queue Entry",29
+2025-08-08T17:56:57.698836Z,"Get Queue Entry",29
+2025-08-08T17:57:00.714823Z,"Get Visit Types",1097
+2025-08-08T17:57:00.884332Z,"Get Current Visit of Patient",648102
+2025-08-08T17:57:00.921921Z,"Get Visits of Patient",42389
+2025-08-08T17:57:00.935102Z,"Get Program Enrollments of Patient",19081
+2025-08-08T17:57:00.941483Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:00.945945Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:02.721999Z,"Get Patient Summary Data",1187
+2025-08-08T17:57:02.722190Z,"Get Patient Summary Data",1187
+2025-08-08T17:57:02.747722Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:02.747854Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:02.754485Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:02.754571Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:02.759076Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:02.759140Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:02.763894Z,"Get the status of patient death",49
+2025-08-08T17:57:02.763956Z,"Get the status of patient death",49
+2025-08-08T17:57:02.769455Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:02.769558Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:02.827460Z,"Get Patient Observations",134452
+2025-08-08T17:57:02.840183Z,"Get Patient Observations",167523
+2025-08-08T17:57:02.863229Z,"Get Patient Observations",108295
+2025-08-08T17:57:02.877321Z,"Get Patient Observations",26645
+2025-08-08T17:57:02.884570Z,"Get Patient Observations",140752
+2025-08-08T17:57:02.886151Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:02.901975Z,"Get Patient Observations",34457
+2025-08-08T17:57:02.908476Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:02.917424Z,"Get Patient Conditions",21827
+2025-08-08T17:57:02.944545Z,"Get Active Orders",111093
+2025-08-08T17:57:02.954664Z,"Get Patient Conditions",36967
+2025-08-08T17:57:02.971602Z,"Get Active Orders",83323
+2025-08-08T17:57:05.995875Z,"Submit Visit Form",1235
+2025-08-08T17:57:06.121147Z,"Get Current Visit of Patient",627390
+2025-08-08T17:57:06.156404Z,"Get Visits of Patient",35411
+2025-08-08T17:57:07.957565Z,"Get Visit Types",1097
+2025-08-08T17:57:07.977978Z,"Get Visit Types",1097
+2025-08-08T17:57:08.022653Z,"Get Current Visit of Patient",109248
+2025-08-08T17:57:08.060192Z,"Get Visits of Patient",92123
+2025-08-08T17:57:08.068572Z,"Get Program Enrollments of Patient",9547
+2025-08-08T17:57:08.074263Z,"Get Visit Queue Entry",0
+2025-08-08T17:57:08.076550Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:08.081419Z,"Get Current Visit of Patient",467002
+2025-08-08T17:57:08.113562Z,"Get Visits of Patient",70880
+2025-08-08T17:57:08.123296Z,"Get Program Enrollments of Patient",18985
+2025-08-08T17:57:08.129168Z,"Get Visit Queue Entry",0
+2025-08-08T17:57:08.131651Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:09.168248Z,"Get Order Types",443
+2025-08-08T17:57:09.187661Z,"Get Active Orders",2526
+2025-08-08T17:57:13.105625Z,"Submit Visit Form",1238
+2025-08-08T17:57:13.143519Z,"Submit Visit Form",1238
+2025-08-08T17:57:13.157159Z,"Get Current Visit of Patient",90389
+2025-08-08T17:57:13.190160Z,"Get Visits of Patient",73264
+2025-08-08T17:57:13.208190Z,"Get Current Visit of Patient",268332
+2025-08-08T17:57:13.239868Z,"Get Visits of Patient",68580
+2025-08-08T17:57:14.210547Z,"Get Active Visits of Patient",581
+2025-08-08T17:57:14.215662Z,"Search for Drug",14
+2025-08-08T17:57:14.219203Z,"Search for Drug",14
+2025-08-08T17:57:14.270580Z,"Save Drug Order",1745
+2025-08-08T17:57:18.222110Z,"Get Active Visits of Patient",584
+2025-08-08T17:57:18.237132Z,"Get Specific Visit Details",570
+2025-08-08T17:57:18.255170Z,"Get Active Visits of Patient",584
+2025-08-08T17:57:18.274471Z,"Get Specific Visit Details",570
+2025-08-08T17:57:18.286600Z,"Get the details of a orderType",533
+2025-08-08T17:57:18.317663Z,"Get All Form Encounters",16152
+2025-08-08T17:57:18.332493Z,"Get all Lab order details",28680
+2025-08-08T17:57:18.337916Z,"Get Module Information",0
+2025-08-08T17:57:18.338137Z,"Get All Forms",5203
+2025-08-08T17:57:18.360004Z,"Add a lab order",1719
+2025-08-08T17:57:19.301538Z,"Get Locations by Tag and Query",10667
+2025-08-08T17:57:19.360544Z,"Get medication request encounters",3555
+2025-08-08T17:57:19.392318Z,"Get patient age",10
+2025-08-08T17:57:19.397279Z,"Get patient age",0
+2025-08-08T17:57:21.439562Z,"Login",1140
+2025-08-08T17:57:21.439713Z,"Login",1140
+2025-08-08T17:57:21.439934Z,"Login",1140
+2025-08-08T17:57:21.440457Z,"Login",1140
+2025-08-08T17:57:21.440707Z,"Login",1140
+2025-08-08T17:57:21.440986Z,"Login",1140
+2025-08-08T17:57:21.441335Z,"Login",1140
+2025-08-08T17:57:21.442341Z,"Login",1140
+2025-08-08T17:57:21.442496Z,"Login",1140
+2025-08-08T17:57:21.443413Z,"Login",1140
+2025-08-08T17:57:22.407204Z,"Get Patient Allergy Intolerance",448
+2025-08-08T17:57:22.485334Z,"Get locations",41279
+2025-08-08T17:57:22.486058Z,"Get locations",41279
+2025-08-08T17:57:22.486348Z,"Get locations",41279
+2025-08-08T17:57:22.486607Z,"Get locations",41279
+2025-08-08T17:57:22.487304Z,"Get locations",41279
+2025-08-08T17:57:22.487671Z,"Get locations",41279
+2025-08-08T17:57:22.487791Z,"Get locations",41279
+2025-08-08T17:57:22.487919Z,"Get locations",41279
+2025-08-08T17:57:22.488865Z,"Get Specific Medication Requests",3568
+2025-08-08T17:57:22.488925Z,"Get locations",41279
+2025-08-08T17:57:22.492813Z,"Get locations",41279
+2025-08-08T17:57:22.496841Z,"Get Encounter With Visit and Diagnoses",210
+2025-08-08T17:57:22.504853Z,"Get All Providers",1359
+2025-08-08T17:57:22.536910Z,"Get Patient Conditions",29086
+2025-08-08T17:57:23.359610Z,"Get Active Visits of Patient",0
+2025-08-08T17:57:23.366549Z,"Get Specific Visit Details",0
+2025-08-08T17:57:23.372217Z,"Get all active Lab orders",1335
+2025-08-08T17:57:23.376774Z,"Get Clinical Form by UUID",1870
+2025-08-08T17:57:23.377546Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:57:23.386005Z,"Get Patient Summary Data",0
+2025-08-08T17:57:23.389771Z,"Get Encounter Roles",187
+2025-08-08T17:57:23.399800Z,"Get Latest FHIR Encounter",1927
+2025-08-08T17:57:23.408817Z,"Get Encounter By UUID",1833
+2025-08-08T17:57:23.441176Z,"Get Lab Orders by full filler status",27421
+2025-08-08T17:57:23.444703Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:57:25.557225Z,"Get Patient Summary Data",1181
+2025-08-08T17:57:25.591732Z,"Get Order Entry Config",26242
+2025-08-08T17:57:25.609313Z,"Get ValueSet by UUID",1660
+2025-08-08T17:57:25.618982Z,"Get ValueSet by UUID",1285
+2025-08-08T17:57:25.639008Z,"Get Medication Request by UUID",1742
+2025-08-08T17:57:25.649286Z,"Get Medication by UUID",879
+2025-08-08T17:57:25.652919Z,"Get All Providers",0
+2025-08-08T17:57:25.656707Z,"Search Medication by Code",4395
+2025-08-08T17:57:25.678927Z,"Get Specific Medication Requests",3568
+2025-08-08T17:57:25.683674Z,"Get patient identification photo",14
+2025-08-08T17:57:25.687834Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:25.694001Z,"Get Active Visits of Patient",1209
+2025-08-08T17:57:25.699936Z,"Get Visit Queue Entry",0
+2025-08-08T17:57:25.702650Z,"Get the status of patient death",49
+2025-08-08T17:57:27.505885Z,"Select Location",1140
+2025-08-08T17:57:27.506710Z,"Select Location",1140
+2025-08-08T17:57:27.506792Z,"Select Location",1140
+2025-08-08T17:57:27.507Z,"Select Location",1140
+2025-08-08T17:57:27.507255Z,"Select Location",1140
+2025-08-08T17:57:27.507659Z,"Select Location",1140
+2025-08-08T17:57:27.507892Z,"Select Location",1140
+2025-08-08T17:57:27.507961Z,"Select Location",1140
+2025-08-08T17:57:27.508309Z,"Select Location",1140
+2025-08-08T17:57:27.512819Z,"Get Address Template",1428
+2025-08-08T17:57:27.513061Z,"Get Address Template",1428
+2025-08-08T17:57:27.513153Z,"Get Address Template",1428
+2025-08-08T17:57:27.513174Z,"Get Address Template",1428
+2025-08-08T17:57:27.513409Z,"Get Address Template",1428
+2025-08-08T17:57:27.513738Z,"Get Address Template",1428
+2025-08-08T17:57:27.513906Z,"Get Address Template",1428
+2025-08-08T17:57:27.513986Z,"Get Address Template",1428
+2025-08-08T17:57:27.514046Z,"Get Address Template",1428
+2025-08-08T17:57:27.514765Z,"Select Location",1140
+2025-08-08T17:57:27.520279Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.520367Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.520432Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.520564Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.520640Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.520713Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.520909Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.521104Z,"Get Address Template",1428
+2025-08-08T17:57:27.521234Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.521376Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.529021Z,"Get Relationship Types",5960
+2025-08-08T17:57:27.541415Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.541564Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.541609Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.541657Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.542181Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.544069Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.544838Z,"Get Module Information",1237
+2025-08-08T17:57:27.544910Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.544984Z,"Get Module Information",1237
+2025-08-08T17:57:27.545114Z,"Get Module Information",1237
+2025-08-08T17:57:27.545184Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.545386Z,"Get Module Information",1237
+2025-08-08T17:57:27.545439Z,"Get Module Information",1237
+2025-08-08T17:57:27.545544Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.545624Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:27.547221Z,"Get Module Information",1237
+2025-08-08T17:57:27.547719Z,"Get Module Information",1237
+2025-08-08T17:57:27.547960Z,"Get Module Information",1237
+2025-08-08T17:57:27.548003Z,"Get Module Information",1237
+2025-08-08T17:57:27.548633Z,"Get Module Information",1237
+2025-08-08T17:57:27.550161Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.550220Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.550246Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.550404Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.550890Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.553151Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.553430Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.553992Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.554244Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.554992Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.555042Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.557984Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.558119Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.558464Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.558643Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:27.570980Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.572776Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.573849Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.574062Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.574408Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:27.575134Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.575331Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.576577Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.576670Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.577315Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.579511Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.579587Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.580528Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.580586Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.581523Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.582521Z,"Get Identifier Source",1233
+2025-08-08T17:57:27.582963Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.583640Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.583683Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.584087Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.587140Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.587212Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.588197Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.588740Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.589103Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:27.594822Z,"Get Visits",2107
+2025-08-08T17:57:27.595497Z,"Get Visits",2107
+2025-08-08T17:57:27.596113Z,"Get Visits",2107
+2025-08-08T17:57:27.596588Z,"Get Visits",2107
+2025-08-08T17:57:27.598306Z,"Get Visits",2107
+2025-08-08T17:57:27.599475Z,"Get Visits",2107
+2025-08-08T17:57:27.600825Z,"Get Visits",2107
+2025-08-08T17:57:27.601116Z,"Get Visits",2107
+2025-08-08T17:57:27.601421Z,"Get Visits",2107
+2025-08-08T17:57:27.603623Z,"Get Visits",2107
+2025-08-08T17:57:27.605055Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.605285Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.606513Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.609388Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.609543Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.609566Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.615216Z,"Get Identifier Source",0
+2025-08-08T17:57:27.615300Z,"Get Identifier Source",0
+2025-08-08T17:57:27.615389Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.615424Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.615504Z,"Get Identifier Source",0
+2025-08-08T17:57:27.616679Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.618535Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:27.621084Z,"Get Identifier Source",0
+2025-08-08T17:57:27.623058Z,"Get Identifier Source",0
+2025-08-08T17:57:27.623722Z,"Get Identifier Source",0
+2025-08-08T17:57:27.623783Z,"Get Identifier Source",0
+2025-08-08T17:57:27.625656Z,"Get Identifier Source",0
+2025-08-08T17:57:27.625705Z,"Get Identifier Source",0
+2025-08-08T17:57:27.627308Z,"Get Queue Entry",29
+2025-08-08T17:57:27.629750Z,"Get Queue Entry",29
+2025-08-08T17:57:27.631107Z,"Get Identifier Source",0
+2025-08-08T17:57:27.632300Z,"Get Queue Entry",29
+2025-08-08T17:57:27.635212Z,"Get Queue Entry",29
+2025-08-08T17:57:27.635328Z,"Get Queue Entry",29
+2025-08-08T17:57:27.640874Z,"Get Queue Entry",29
+2025-08-08T17:57:27.642964Z,"Get Queue Entry",29
+2025-08-08T17:57:27.643047Z,"Get Queue Entry",29
+2025-08-08T17:57:27.645023Z,"Get Queue Entry",29
+2025-08-08T17:57:27.645538Z,"Get Queue Entry",29
+2025-08-08T17:57:27.646214Z,"Get Patient Summary Data",3583
+2025-08-08T17:57:27.650353Z,"Get Patient Summary Data",1483
+2025-08-08T17:57:27.656888Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:27.657028Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:27.659730Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:27.659802Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:27.661897Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:27.661911Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:27.665241Z,"Get the status of patient death",49
+2025-08-08T17:57:27.668260Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:27.668973Z,"Get the status of patient death",49
+2025-08-08T17:57:27.671655Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:27.733653Z,"Get Patient Observations",164740
+2025-08-08T17:57:27.736601Z,"Get Patient Observations",162548
+2025-08-08T17:57:27.784133Z,"Get Patient Observations",129982
+2025-08-08T17:57:27.793868Z,"Get Patient Observations",181292
+2025-08-08T17:57:27.813055Z,"Get Patient Observations",33054
+2025-08-08T17:57:27.818826Z,"Get Patient Observations",57241
+2025-08-08T17:57:27.822746Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:27.824092Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:27.858223Z,"Get Patient Conditions",29446
+2025-08-08T17:57:27.860626Z,"Get Patient Conditions",26531
+2025-08-08T17:57:27.865259Z,"Get Active Orders",14
+2025-08-08T17:57:27.869070Z,"Get Active Orders",14
+2025-08-08T17:57:28.459669Z,"Save a clinical form",1833
+2025-08-08T17:57:28.459717Z,"Update full filler status",0
+2025-08-08T17:57:28.465997Z,"Get Active Visits of Patient",0
+2025-08-08T17:57:28.468645Z,"Get all active Lab orders",1342
+2025-08-08T17:57:28.471376Z,"Get Specific Visit Details",0
+2025-08-08T17:57:28.476504Z,"Get Lab Orders by full filler status",1342
+2025-08-08T17:57:28.524013Z,"Get Lab Orders by full filler status",27421
+2025-08-08T17:57:28.527Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:57:30.639287Z,"Get Visit Types",1097
+2025-08-08T17:57:30.651705Z,"Get Address Template",0
+2025-08-08T17:57:30.653362Z,"Get Admission Location Info",1836
+2025-08-08T17:57:30.661174Z,"Get Patient Identifier Types",0
+2025-08-08T17:57:30.667299Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:30.672456Z,"Get Relationship Types",0
+2025-08-08T17:57:30.675813Z,"Get Module Information",0
+2025-08-08T17:57:30.680616Z,"Get Person Attribute Type",622
+2025-08-08T17:57:30.685930Z,"Get Admission Info",14
+2025-08-08T17:57:30.690360Z,"Get Auto Generation Options",0
+2025-08-08T17:57:30.692742Z,"Get Ordered Address Hierarchy Levels",2
+2025-08-08T17:57:30.697822Z,"Get Identifier Source",0
+2025-08-08T17:57:30.699368Z,"Get Inpatient Request",14
+2025-08-08T17:57:30.701182Z,"Get all patient lists",31754
+2025-08-08T17:57:30.708466Z,"Get all patient lists",29
+2025-08-08T17:57:30.722074Z,"Get Current Visit of Patient",105512
+2025-08-08T17:57:30.742759Z,"Get all patient lists",31802
+2025-08-08T17:57:30.761585Z,"Dispense medication form submission",1952
+2025-08-08T17:57:30.773224Z,"Get Visits of Patient",115873
+2025-08-08T17:57:30.777271Z,"Get Patients",107417
+2025-08-08T17:57:30.778090Z,"Get Patients",107417
+2025-08-08T17:57:30.782096Z,"Get Program Enrollments of Patient",4662
+2025-08-08T17:57:30.782455Z,"Get Patients",107417
+2025-08-08T17:57:30.786857Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.786908Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.787662Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:30.789340Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.791274Z,"Get patient identification photo",14
+2025-08-08T17:57:30.791542Z,"Get patient identification photo",14
+2025-08-08T17:57:30.793942Z,"Get patient identification photo",14
+2025-08-08T17:57:30.794096Z,"Get Appointments of a Patient",1149
+2025-08-08T17:57:30.794584Z,"Get the status of patient death",49
+2025-08-08T17:57:30.794985Z,"Get the status of patient death",49
+2025-08-08T17:57:30.797006Z,"Get the status of patient death",49
+2025-08-08T17:57:30.797799Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.797991Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.800332Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.801234Z,"Get patient identification photo",14
+2025-08-08T17:57:30.801418Z,"Get patient identification photo",14
+2025-08-08T17:57:30.803918Z,"Get patient identification photo",14
+2025-08-08T17:57:30.803941Z,"Get the status of patient death",49
+2025-08-08T17:57:30.804092Z,"Get the status of patient death",49
+2025-08-08T17:57:30.806991Z,"Get the status of patient death",49
+2025-08-08T17:57:30.807443Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.808261Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.810936Z,"Get medication request encounters",5626
+2025-08-08T17:57:30.812025Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.813273Z,"Get patient identification photo",14
+2025-08-08T17:57:30.813786Z,"Get patient identification photo",14
+2025-08-08T17:57:30.816787Z,"Get the status of patient death",49
+2025-08-08T17:57:30.817186Z,"Get patient identification photo",14
+2025-08-08T17:57:30.817303Z,"Get the status of patient death",49
+2025-08-08T17:57:30.820768Z,"Get the status of patient death",49
+2025-08-08T17:57:30.821149Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.822119Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.825243Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.826459Z,"Get patient identification photo",14
+2025-08-08T17:57:30.827856Z,"Get patient identification photo",14
+2025-08-08T17:57:30.830562Z,"Get the status of patient death",49
+2025-08-08T17:57:30.830710Z,"Get patient identification photo",14
+2025-08-08T17:57:30.831135Z,"Get the status of patient death",49
+2025-08-08T17:57:30.834380Z,"Get the status of patient death",49
+2025-08-08T17:57:30.835045Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.835535Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.837300Z,"Get Medication Request by UUID",0
+2025-08-08T17:57:30.838436Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.840452Z,"Get patient identification photo",14
+2025-08-08T17:57:30.840950Z,"Get patient identification photo",14
+2025-08-08T17:57:30.843740Z,"Get patient identification photo",14
+2025-08-08T17:57:30.844245Z,"Get the status of patient death",49
+2025-08-08T17:57:30.844271Z,"Get the status of patient death",49
+2025-08-08T17:57:30.847957Z,"Get the status of patient death",49
+2025-08-08T17:57:30.848786Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.849248Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.852278Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.853078Z,"Get patient identification photo",14
+2025-08-08T17:57:30.853103Z,"Get patient identification photo",14
+2025-08-08T17:57:30.857101Z,"Get the status of patient death",49
+2025-08-08T17:57:30.857169Z,"Get the status of patient death",49
+2025-08-08T17:57:30.858634Z,"Get patient identification photo",14
+2025-08-08T17:57:30.861224Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.861316Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.861709Z,"Get the status of patient death",49
+2025-08-08T17:57:30.865066Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.865610Z,"Get patient identification photo",14
+2025-08-08T17:57:30.865633Z,"Get patient identification photo",14
+2025-08-08T17:57:30.868986Z,"Get the status of patient death",49
+2025-08-08T17:57:30.869436Z,"Get the status of patient death",49
+2025-08-08T17:57:30.870465Z,"Get patient identification photo",14
+2025-08-08T17:57:30.873232Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.873710Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.874103Z,"Get the status of patient death",49
+2025-08-08T17:57:30.878132Z,"Get patient identification photo",14
+2025-08-08T17:57:30.878147Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.878160Z,"Get patient identification photo",14
+2025-08-08T17:57:30.881760Z,"Get the status of patient death",49
+2025-08-08T17:57:30.882334Z,"Get the status of patient death",49
+2025-08-08T17:57:30.883568Z,"Get patient identification photo",14
+2025-08-08T17:57:30.886417Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.886677Z,"Get the status of patient death",49
+2025-08-08T17:57:30.886873Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.889370Z,"Get Specific Medication Requests",5639
+2025-08-08T17:57:30.890244Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.890633Z,"Get patient identification photo",14
+2025-08-08T17:57:30.890946Z,"Get patient identification photo",14
+2025-08-08T17:57:30.893419Z,"Get the status of patient death",49
+2025-08-08T17:57:30.893678Z,"Get the status of patient death",49
+2025-08-08T17:57:30.894572Z,"Get patient identification photo",14
+2025-08-08T17:57:30.896994Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.897011Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.897522Z,"Get the status of patient death",49
+2025-08-08T17:57:30.900562Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.901104Z,"Get patient identification photo",14
+2025-08-08T17:57:30.901294Z,"Get patient identification photo",14
+2025-08-08T17:57:30.904105Z,"Get the status of patient death",49
+2025-08-08T17:57:30.904118Z,"Get the status of patient death",49
+2025-08-08T17:57:30.905373Z,"Get patient identification photo",14
+2025-08-08T17:57:30.907577Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.907630Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.908123Z,"Get the status of patient death",49
+2025-08-08T17:57:30.912016Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.912396Z,"Get patient identification photo",14
+2025-08-08T17:57:30.912414Z,"Get patient identification photo",14
+2025-08-08T17:57:30.915226Z,"Get the status of patient death",49
+2025-08-08T17:57:30.915255Z,"Get the status of patient death",49
+2025-08-08T17:57:30.916511Z,"Get patient identification photo",14
+2025-08-08T17:57:30.918521Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.918569Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.919145Z,"Get the status of patient death",49
+2025-08-08T17:57:30.922481Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.923114Z,"Get patient identification photo",14
+2025-08-08T17:57:30.923304Z,"Get patient identification photo",14
+2025-08-08T17:57:30.926084Z,"Get the status of patient death",49
+2025-08-08T17:57:30.926312Z,"Get the status of patient death",49
+2025-08-08T17:57:30.926784Z,"Get patient identification photo",14
+2025-08-08T17:57:30.929493Z,"Get the status of patient death",49
+2025-08-08T17:57:30.929930Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.930205Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.932706Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.933370Z,"Get patient identification photo",14
+2025-08-08T17:57:30.933402Z,"Get patient identification photo",14
+2025-08-08T17:57:30.935621Z,"Get the status of patient death",49
+2025-08-08T17:57:30.935662Z,"Get the status of patient death",49
+2025-08-08T17:57:30.936036Z,"Get patient identification photo",14
+2025-08-08T17:57:30.938312Z,"Get the status of patient death",49
+2025-08-08T17:57:30.938649Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.938682Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.941270Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.941891Z,"Get patient identification photo",14
+2025-08-08T17:57:30.941934Z,"Get patient identification photo",14
+2025-08-08T17:57:30.944114Z,"Get the status of patient death",49
+2025-08-08T17:57:30.944210Z,"Get the status of patient death",49
+2025-08-08T17:57:30.944576Z,"Get patient identification photo",14
+2025-08-08T17:57:30.946804Z,"Get the status of patient death",49
+2025-08-08T17:57:30.947104Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.947145Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.949806Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.950416Z,"Get patient identification photo",14
+2025-08-08T17:57:30.950469Z,"Get patient identification photo",14
+2025-08-08T17:57:30.952941Z,"Get the status of patient death",49
+2025-08-08T17:57:30.952963Z,"Get the status of patient death",49
+2025-08-08T17:57:30.953238Z,"Get patient identification photo",14
+2025-08-08T17:57:30.955876Z,"Get the status of patient death",49
+2025-08-08T17:57:30.956313Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.956557Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.959084Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.959806Z,"Get patient identification photo",14
+2025-08-08T17:57:30.959967Z,"Get patient identification photo",14
+2025-08-08T17:57:30.962319Z,"Get the status of patient death",49
+2025-08-08T17:57:30.962455Z,"Get the status of patient death",49
+2025-08-08T17:57:30.962903Z,"Get patient identification photo",14
+2025-08-08T17:57:30.965357Z,"Get the status of patient death",49
+2025-08-08T17:57:30.965820Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.966063Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.968648Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.969224Z,"Get patient identification photo",14
+2025-08-08T17:57:30.969436Z,"Get patient identification photo",14
+2025-08-08T17:57:30.971501Z,"Get the status of patient death",49
+2025-08-08T17:57:30.971767Z,"Get patient identification photo",14
+2025-08-08T17:57:30.971875Z,"Get the status of patient death",49
+2025-08-08T17:57:30.974105Z,"Get the status of patient death",49
+2025-08-08T17:57:30.974453Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.974693Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.977116Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.978081Z,"Get patient identification photo",14
+2025-08-08T17:57:30.978221Z,"Get patient identification photo",14
+2025-08-08T17:57:30.980757Z,"Get the status of patient death",49
+2025-08-08T17:57:30.980939Z,"Get patient identification photo",14
+2025-08-08T17:57:30.981079Z,"Get the status of patient death",49
+2025-08-08T17:57:30.983782Z,"Get the status of patient death",49
+2025-08-08T17:57:30.984420Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.984431Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.987331Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.988198Z,"Get patient identification photo",14
+2025-08-08T17:57:30.988262Z,"Get patient identification photo",14
+2025-08-08T17:57:30.990879Z,"Get the status of patient death",49
+2025-08-08T17:57:30.990896Z,"Get the status of patient death",49
+2025-08-08T17:57:30.991130Z,"Get patient identification photo",14
+2025-08-08T17:57:30.993878Z,"Get the status of patient death",49
+2025-08-08T17:57:30.994294Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:30.994581Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.001733Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.002271Z,"Get patient identification photo",14
+2025-08-08T17:57:31.002302Z,"Get patient identification photo",14
+2025-08-08T17:57:31.006222Z,"Get the status of patient death",49
+2025-08-08T17:57:31.006566Z,"Get the status of patient death",49
+2025-08-08T17:57:31.007617Z,"Get patient identification photo",14
+2025-08-08T17:57:31.011212Z,"Get the status of patient death",49
+2025-08-08T17:57:31.011239Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.011522Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.016356Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.016391Z,"Get patient identification photo",14
+2025-08-08T17:57:31.016463Z,"Get patient identification photo",14
+2025-08-08T17:57:31.020218Z,"Get the status of patient death",49
+2025-08-08T17:57:31.020280Z,"Get the status of patient death",49
+2025-08-08T17:57:31.022454Z,"Get patient identification photo",14
+2025-08-08T17:57:31.024635Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.025193Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.026310Z,"Get the status of patient death",49
+2025-08-08T17:57:31.029691Z,"Get patient identification photo",14
+2025-08-08T17:57:31.030029Z,"Get patient identification photo",14
+2025-08-08T17:57:31.031257Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.033554Z,"Get the status of patient death",49
+2025-08-08T17:57:31.033893Z,"Get the status of patient death",49
+2025-08-08T17:57:31.036332Z,"Get patient identification photo",14
+2025-08-08T17:57:31.037862Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.038873Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.040147Z,"Get the status of patient death",49
+2025-08-08T17:57:31.042878Z,"Get patient identification photo",14
+2025-08-08T17:57:31.043682Z,"Get patient identification photo",14
+2025-08-08T17:57:31.043732Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.047676Z,"Get the status of patient death",49
+2025-08-08T17:57:31.047900Z,"Get patient identification photo",14
+2025-08-08T17:57:31.048462Z,"Get the status of patient death",49
+2025-08-08T17:57:31.052539Z,"Get the status of patient death",49
+2025-08-08T17:57:31.053131Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.053565Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.056896Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.058144Z,"Get patient identification photo",14
+2025-08-08T17:57:31.058908Z,"Get patient identification photo",14
+2025-08-08T17:57:31.061467Z,"Get patient identification photo",14
+2025-08-08T17:57:31.061802Z,"Get the status of patient death",49
+2025-08-08T17:57:31.062946Z,"Get the status of patient death",49
+2025-08-08T17:57:31.065483Z,"Get the status of patient death",49
+2025-08-08T17:57:31.066410Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.067216Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.069760Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.071072Z,"Get patient identification photo",14
+2025-08-08T17:57:31.072871Z,"Get patient identification photo",14
+2025-08-08T17:57:31.074341Z,"Get patient identification photo",14
+2025-08-08T17:57:31.074377Z,"Get the status of patient death",49
+2025-08-08T17:57:31.102992Z,"Get the status of patient death",49
+2025-08-08T17:57:31.103868Z,"Get the status of patient death",49
+2025-08-08T17:57:31.105141Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.107236Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.108200Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.109669Z,"Get patient identification photo",14
+2025-08-08T17:57:31.112024Z,"Get patient identification photo",14
+2025-08-08T17:57:31.112997Z,"Get the status of patient death",49
+2025-08-08T17:57:31.113484Z,"Get patient identification photo",14
+2025-08-08T17:57:31.115593Z,"Get the status of patient death",49
+2025-08-08T17:57:31.116624Z,"Get the status of patient death",49
+2025-08-08T17:57:31.116735Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.119869Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.120655Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.120676Z,"Get patient identification photo",14
+2025-08-08T17:57:31.123759Z,"Get the status of patient death",49
+2025-08-08T17:57:31.124382Z,"Get patient identification photo",14
+2025-08-08T17:57:31.125214Z,"Get patient identification photo",14
+2025-08-08T17:57:31.127606Z,"Get the status of patient death",49
+2025-08-08T17:57:31.128141Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.128539Z,"Get the status of patient death",49
+2025-08-08T17:57:31.132170Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.132734Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.133138Z,"Get patient identification photo",14
+2025-08-08T17:57:31.136621Z,"Get the status of patient death",49
+2025-08-08T17:57:31.136976Z,"Get patient identification photo",14
+2025-08-08T17:57:31.137123Z,"Get patient identification photo",14
+2025-08-08T17:57:31.139927Z,"Get the status of patient death",49
+2025-08-08T17:57:31.140658Z,"Get the status of patient death",49
+2025-08-08T17:57:31.140687Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.143848Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.144671Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.144934Z,"Get patient identification photo",14
+2025-08-08T17:57:31.148974Z,"Get the status of patient death",49
+2025-08-08T17:57:31.149263Z,"Get patient identification photo",14
+2025-08-08T17:57:31.149550Z,"Get patient identification photo",14
+2025-08-08T17:57:31.151980Z,"Get the status of patient death",49
+2025-08-08T17:57:31.152005Z,"Get the status of patient death",49
+2025-08-08T17:57:31.152292Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.154871Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.154887Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.155336Z,"Get patient identification photo",14
+2025-08-08T17:57:31.157485Z,"Get the status of patient death",49
+2025-08-08T17:57:31.157840Z,"Get patient identification photo",14
+2025-08-08T17:57:31.158066Z,"Get patient identification photo",14
+2025-08-08T17:57:31.160146Z,"Get the status of patient death",49
+2025-08-08T17:57:31.160165Z,"Get the status of patient death",49
+2025-08-08T17:57:31.160409Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.163043Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.163071Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.163481Z,"Get patient identification photo",14
+2025-08-08T17:57:31.165616Z,"Get the status of patient death",49
+2025-08-08T17:57:31.166121Z,"Get patient identification photo",14
+2025-08-08T17:57:31.166262Z,"Get patient identification photo",14
+2025-08-08T17:57:31.168234Z,"Get the status of patient death",49
+2025-08-08T17:57:31.168402Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.168472Z,"Get the status of patient death",49
+2025-08-08T17:57:31.170881Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.171094Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.171410Z,"Get patient identification photo",14
+2025-08-08T17:57:31.173536Z,"Get the status of patient death",49
+2025-08-08T17:57:31.173950Z,"Get patient identification photo",14
+2025-08-08T17:57:31.174050Z,"Get patient identification photo",14
+2025-08-08T17:57:31.176190Z,"Get the status of patient death",49
+2025-08-08T17:57:31.176206Z,"Get the status of patient death",49
+2025-08-08T17:57:31.176373Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.179071Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.179112Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.179461Z,"Get patient identification photo",14
+2025-08-08T17:57:31.181658Z,"Get the status of patient death",49
+2025-08-08T17:57:31.182299Z,"Get patient identification photo",14
+2025-08-08T17:57:31.182315Z,"Get patient identification photo",14
+2025-08-08T17:57:31.184657Z,"Get the status of patient death",49
+2025-08-08T17:57:31.184666Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.185002Z,"Get the status of patient death",49
+2025-08-08T17:57:31.187872Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.187898Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.188499Z,"Get patient identification photo",14
+2025-08-08T17:57:31.190661Z,"Get the status of patient death",49
+2025-08-08T17:57:31.191221Z,"Get patient identification photo",14
+2025-08-08T17:57:31.191416Z,"Get patient identification photo",14
+2025-08-08T17:57:31.193549Z,"Get the status of patient death",49
+2025-08-08T17:57:31.193607Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.193664Z,"Get the status of patient death",49
+2025-08-08T17:57:31.196324Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.196362Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.196664Z,"Get patient identification photo",14
+2025-08-08T17:57:31.198900Z,"Get the status of patient death",49
+2025-08-08T17:57:31.199471Z,"Get patient identification photo",14
+2025-08-08T17:57:31.199489Z,"Get patient identification photo",14
+2025-08-08T17:57:31.201557Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.201677Z,"Get the status of patient death",49
+2025-08-08T17:57:31.201738Z,"Get the status of patient death",49
+2025-08-08T17:57:31.204359Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.204390Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:31.204751Z,"Get patient identification photo",14
+2025-08-08T17:57:31.206852Z,"Get the status of patient death",49
+2025-08-08T17:57:31.207395Z,"Get patient identification photo",14
+2025-08-08T17:57:31.207464Z,"Get patient identification photo",14
+2025-08-08T17:57:31.209704Z,"Get the status of patient death",49
+2025-08-08T17:57:31.209720Z,"Get the status of patient death",49
+2025-08-08T17:57:31.211584Z,"Get All Appointment Services(full)",1297
+2025-08-08T17:57:31.213664Z,"Get all appointments for a specific day",2
+2025-08-08T17:57:31.221317Z,"Get all appointment summaries",1719
+2025-08-08T17:57:31.234411Z,"Get Appointment By Status",4589
+2025-08-08T17:57:31.236950Z,"Get Appointment By Status",2
+2025-08-08T17:57:31.239103Z,"Get Appointment By Status",2
+2025-08-08T17:57:31.241047Z,"Get Appointment By Status",2
+2025-08-08T17:57:31.242703Z,"Get all default appointment services",1085
+2025-08-08T17:57:31.247908Z,"Get all visits of the given location with date",1789
+2025-08-08T17:57:31.533040Z,"Get Visits of Patient",0
+2025-08-08T17:57:31.624222Z,"Get Patient Encounters",135362
+2025-08-08T17:57:31.657605Z,"Get Lab Results of Patient",45165
+2025-08-08T17:57:31.668534Z,"Get Concept",8099
+2025-08-08T17:57:31.673292Z,"Get Concept",10606
+2025-08-08T17:57:31.676967Z,"Get Concept",6068
+2025-08-08T17:57:31.680824Z,"Get Concept",8144
+2025-08-08T17:57:31.685012Z,"Get Concept",10640
+2025-08-08T17:57:31.689762Z,"Get Concept",12276
+2025-08-08T17:57:31.694023Z,"Get Concept",12182
+2025-08-08T17:57:31.698349Z,"Get Concept",13808
+2025-08-08T17:57:31.701873Z,"Get Concept",8522
+2025-08-08T17:57:31.706344Z,"Get Concept",13996
+2025-08-08T17:57:31.711263Z,"Get Concept",15533
+2025-08-08T17:57:31.716549Z,"Get Concept",18399
+2025-08-08T17:57:31.720716Z,"Get Concept",10999
+2025-08-08T17:57:31.725963Z,"Get Concept",19038
+2025-08-08T17:57:31.729716Z,"Get Concept",9143
+2025-08-08T17:57:31.733403Z,"Get Concept",10098
+2025-08-08T17:57:31.737384Z,"Get Concept",12109
+2025-08-08T17:57:31.743099Z,"Get Concept",20084
+2025-08-08T17:57:31.746731Z,"Get Concept",8885
+2025-08-08T17:57:31.750354Z,"Get Concept",7795
+2025-08-08T17:57:31.754219Z,"Get Concept",0
+2025-08-08T17:57:31.757989Z,"Get Concept",0
+2025-08-08T17:57:31.762172Z,"Get Concept",0
+2025-08-08T17:57:31.767401Z,"Get Concept",21319
+2025-08-08T17:57:31.772510Z,"Get Concept",20273
+2025-08-08T17:57:31.777135Z,"Get Concept",14307
+2025-08-08T17:57:31.781725Z,"Get Concept",0
+2025-08-08T17:57:31.786386Z,"Get Concept",0
+2025-08-08T17:57:32.654028Z,"Get Patient Summary Data",1179
+2025-08-08T17:57:32.655573Z,"Get Patient Summary Data",1185
+2025-08-08T17:57:32.664608Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:32.664681Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:32.669963Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:32.670109Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:32.673173Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:32.673197Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:32.677568Z,"Get the status of patient death",49
+2025-08-08T17:57:32.677594Z,"Get the status of patient death",49
+2025-08-08T17:57:32.681654Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:32.681694Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:32.706378Z,"Get Patient Observations",54383
+2025-08-08T17:57:32.711232Z,"Get Patient Observations",67622
+2025-08-08T17:57:32.723660Z,"Get Patient Observations",43882
+2025-08-08T17:57:32.731117Z,"Get Patient Observations",54485
+2025-08-08T17:57:32.734045Z,"Get Patient Observations",10988
+2025-08-08T17:57:32.739123Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:32.740491Z,"Get Patient Observations",13625
+2025-08-08T17:57:32.745317Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:32.756219Z,"Get Patient Conditions",10930
+2025-08-08T17:57:32.760900Z,"Get Active Orders",14
+2025-08-08T17:57:32.771813Z,"Get Patient Conditions",23993
+2025-08-08T17:57:32.775645Z,"Get Active Orders",14
+2025-08-08T17:57:32.871851Z,"Get Address Template",0
+2025-08-08T17:57:32.875043Z,"Get Patient Identifier Types",0
+2025-08-08T17:57:32.877886Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:32.880158Z,"Get Relationship Types",0
+2025-08-08T17:57:32.881464Z,"Get Module Information",0
+2025-08-08T17:57:32.884054Z,"Get Person Attribute Type",622
+2025-08-08T17:57:32.888768Z,"Get Auto Generation Options",0
+2025-08-08T17:57:32.889725Z,"Get Ordered Address Hierarchy Levels",2
+2025-08-08T17:57:32.892320Z,"Get Identifier Source",0
+2025-08-08T17:57:32.898675Z,"Get the status of patient death",0
+2025-08-08T17:57:32.905731Z,"Get patient identification photo",14
+2025-08-08T17:57:32.913779Z,"Get Patient Summary Data",0
+2025-08-08T17:57:32.918450Z,"Get Patient Observations",181292
+2025-08-08T17:57:32.921030Z,"Get Person Attributes",14
+2025-08-08T17:57:32.929252Z,"Get Patient Identifiers",202
+2025-08-08T17:57:32.939838Z,"Get Relationships of Person",14
+2025-08-08T17:57:32.947625Z,"Get Patient Observations",57241
+2025-08-08T17:57:33.546032Z,"Get specific encounter details",797
+2025-08-08T17:57:33.551653Z,"Get Alkaline concept details",1387
+2025-08-08T17:57:33.577947Z,"Update the specific encounter",1934
+2025-08-08T17:57:33.594513Z,"Update the Lab Order Completion",2777
+2025-08-08T17:57:33.601590Z,"Update full filler status",0
+2025-08-08T17:57:33.604715Z,"Get all active Lab orders",14
+2025-08-08T17:57:33.607420Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:57:33.654906Z,"Get Lab Orders by full filler status",28794
+2025-08-08T17:57:33.657943Z,"Get Lab Orders by full filler status",0
+2025-08-08T17:57:33.759511Z,"Create a patient list",1039
+2025-08-08T17:57:33.789093Z,"Get all patient lists",31754
+2025-08-08T17:57:33.794095Z,"Get Visits With Diagnoses and Notes (new endpoint)",3673
+2025-08-08T17:57:33.898328Z,"Get Patient Summary Data",0
+2025-08-08T17:57:33.910790Z,"Get ValueSet by UUID",2315
+2025-08-08T17:57:33.915150Z,"Get patient identification photo",0
+2025-08-08T17:57:33.917960Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:33.924584Z,"Get Active Visits of Patient",0
+2025-08-08T17:57:33.927409Z,"Get the status of patient death",0
+2025-08-08T17:57:34.218212Z,"Get Visit Types",1097
+2025-08-08T17:57:34.218288Z,"Get Visit Types",1097
+2025-08-08T17:57:34.230633Z,"Get Locations That Support Visits",2180
+2025-08-08T17:57:34.230704Z,"Get Locations That Support Visits",2180
+2025-08-08T17:57:34.241890Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:57:34.248344Z,"Get Program Enrollments of Patient",4586
+2025-08-08T17:57:34.249787Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:57:34.252542Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:34.253158Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:34.255162Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:57:34.257370Z,"Get the status of patient death",49
+2025-08-08T17:57:34.261901Z,"Get Appointments of a Patient",1149
+2025-08-08T17:57:34.263053Z,"Get Patient Summary Data",1185
+2025-08-08T17:57:34.264045Z,"Submit Visit Form",1235
+2025-08-08T17:57:34.265953Z,"Get All Appointment Services(full)",0
+2025-08-08T17:57:34.268033Z,"Get patient identification photo",14
+2025-08-08T17:57:34.269502Z,"Get patient identification photo",14
+2025-08-08T17:57:34.270954Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:34.271237Z,"Submit Visit Form",1233
+2025-08-08T17:57:34.274447Z,"Get Beds for Patient",14
+2025-08-08T17:57:34.275132Z,"Get Queue Entry",29
+2025-08-08T17:57:34.275240Z,"Get Patient Summary Data",1179
+2025-08-08T17:57:34.279580Z,"Get All Providers",1359
+2025-08-08T17:57:34.282085Z,"Get Active Visits of Patient",581
+2025-08-08T17:57:34.283048Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:34.287401Z,"Save Ward Encounter",1775
+2025-08-08T17:57:34.287857Z,"Get Queue Entry",29
+2025-08-08T17:57:34.290368Z,"Get the status of patient death",49
+2025-08-08T17:57:34.291546Z,"Get queue entry number",97
+2025-08-08T17:57:34.309580Z,"Submit visit queue entry",7802
+2025-08-08T17:57:34.320694Z,"Get Queue Entry",8940
+2025-08-08T17:57:35.832184Z,"Submit Visit Form",1238
+2025-08-08T17:57:35.877957Z,"Get Current Visit of Patient",86653
+2025-08-08T17:57:35.908188Z,"Get Visits of Patient",97014
+2025-08-08T17:57:36.806910Z,"Get patient list details",689
+2025-08-08T17:57:36.818798Z,"Fetch members of patient list",14
+2025-08-08T17:57:36.834589Z,"Login",1140
+2025-08-08T17:57:36.960544Z,"Close medication",1415
+2025-08-08T17:57:37.019432Z,"Get medication request encounters",7160
+2025-08-08T17:57:37.038528Z,"Get Medication Request by UUID",0
+2025-08-08T17:57:37.076700Z,"Get Specific Medication Requests",7173
+2025-08-08T17:57:37.091813Z,"Discontinue the drug order",3275
+2025-08-08T17:57:37.109595Z,"End Visit",1481
+2025-08-08T17:57:37.256030Z,"Get Current Visit of Patient",646243
+2025-08-08T17:57:37.307619Z,"Get Visits of Patient",54264
+2025-08-08T17:57:37.322483Z,"Login",1140
+2025-08-08T17:57:37.324596Z,"Get service concept set",48
+2025-08-08T17:57:37.328538Z,"Get Concept",7419
+2025-08-08T17:57:37.340897Z,"Submit new Service queue",2208
+2025-08-08T17:57:37.770941Z,"Get Visit Types",1097
+2025-08-08T17:57:37.782746Z,"Get Visit Types",1097
+2025-08-08T17:57:37.834891Z,"Get Current Visit of Patient",114692
+2025-08-08T17:57:37.852640Z,"Get locations",41279
+2025-08-08T17:57:37.870659Z,"Get Visits of Patient",56398
+2025-08-08T17:57:37.877370Z,"Get Program Enrollments of Patient",4586
+2025-08-08T17:57:37.883120Z,"Get Visit Queue Entry",0
+2025-08-08T17:57:37.885529Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:37.955254Z,"Get Current Visit of Patient",1004562
+2025-08-08T17:57:37.972485Z,"Edit patient details",1829
+2025-08-08T17:57:37.980059Z,"Login",1140
+2025-08-08T17:57:37.987874Z,"Get Visits of Patient",33073
+2025-08-08T17:57:38.002034Z,"Get Program Enrollments of Patient",42916
+2025-08-08T17:57:38.007678Z,"Get Visit Queue Entry",0
+2025-08-08T17:57:38.013704Z,"Get Appointments of a Patient",1147
+2025-08-08T17:57:38.043530Z,"Save Vitals",3199
+2025-08-08T17:57:38.359099Z,"Get locations",41279
+2025-08-08T17:57:38.711673Z,"End Visit",1484
+2025-08-08T17:57:38.791275Z,"Get Current Visit of Patient",289059
+2025-08-08T17:57:38.821017Z,"Get Drug Orders except the cancelled and expired",111093
+2025-08-08T17:57:38.831484Z,"Get Visits of Patient",75564
+2025-08-08T17:57:38.839310Z,"Login",1140
+2025-08-08T17:57:38.844284Z,"Get Drug Orders except the discontinued orders",111093
+2025-08-08T17:57:38.849337Z,"Get Active Visits of Patient",0
+2025-08-08T17:57:38.913864Z,"Get Order Types",443
+2025-08-08T17:57:38.923761Z,"Get Active Orders",7319
+2025-08-08T17:57:39.005560Z,"Get locations",41279
+2025-08-08T17:57:39.301884Z,"Check Appointment Conflicts",0
+2025-08-08T17:57:39.307383Z,"Get Active Visits of Patient",1380
+2025-08-08T17:57:39.311703Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:39.317130Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:39.325182Z,"Create Appointment",1213
+2025-08-08T17:57:39.360041Z,"Get Patient Observations",129435
+2025-08-08T17:57:39.413312Z,"Get Vitals concept reference ranges",2824
+2025-08-08T17:57:39.418745Z,"Get Specific Visit Details",1366
+2025-08-08T17:57:39.446548Z,"Get Transfer Locations configuration data",10181
+2025-08-08T17:57:39.463904Z,"Get Transferable locations",4651
+2025-08-08T17:57:39.487164Z,"Save Ward Encounter",2058
+2025-08-08T17:57:39.883004Z,"Get locations",41279
+2025-08-08T17:57:40.393353Z,"Submit transition request",1673
+2025-08-08T17:57:40.413406Z,"Get Queue Entry",18965
+2025-08-08T17:57:40.443541Z,"End Visit",1261
+2025-08-08T17:57:40.454290Z,"Get Current Visit of Patient",11302
+2025-08-08T17:57:40.466Z,"Get Visits of Patient",21663
+2025-08-08T17:57:40.473325Z,"Login",1140
+2025-08-08T17:57:40.731085Z,"Generate OMRS Identifier",24
+2025-08-08T17:57:40.772658Z,"Send Patient Registration Request",1870
+2025-08-08T17:57:41.508183Z,"Get locations",41279
+2025-08-08T17:57:42.794091Z,"Get Patient Summary Data",1208
+2025-08-08T17:57:42.804699Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:42.810259Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:42.814594Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:42.819040Z,"Get the status of patient death",49
+2025-08-08T17:57:42.824698Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:42.828260Z,"Get Patient Observations",867
+2025-08-08T17:57:42.830753Z,"Get Patient Observations",750
+2025-08-08T17:57:42.832676Z,"Get Patient Observations",594
+2025-08-08T17:57:42.839922Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:42.841751Z,"Get Patient Conditions",450
+2025-08-08T17:57:42.847030Z,"Get Active Orders",14
+2025-08-08T17:57:42.854005Z,"Login",1140
+2025-08-08T17:57:42.855824Z,"Select Location",1140
+2025-08-08T17:57:42.856989Z,"Get Address Template",1428
+2025-08-08T17:57:42.859121Z,"Get Relationship Types",5960
+2025-08-08T17:57:42.867617Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:42.869081Z,"Get Module Information",1237
+2025-08-08T17:57:42.872108Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:42.874548Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:42.880797Z,"Get Identifier Source",1233
+2025-08-08T17:57:42.884133Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:42.889355Z,"Get Visits",1416
+2025-08-08T17:57:42.894264Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:42.895416Z,"Submit Visit Form",1234
+2025-08-08T17:57:42.897140Z,"Get Identifier Source",0
+2025-08-08T17:57:42.900695Z,"Get Queue Entry",29
+2025-08-08T17:57:42.932911Z,"Get Current Visit of Patient",93985
+2025-08-08T17:57:42.959640Z,"Get Visits of Patient",49422
+2025-08-08T17:57:43.025166Z,"Submit Visit Form",1238
+2025-08-08T17:57:43.059329Z,"Get Allergies of Patient",15314
+2025-08-08T17:57:43.088771Z,"Get Drug Allergens",118868
+2025-08-08T17:57:43.106132Z,"Get Environment Allergens",93956
+2025-08-08T17:57:43.113902Z,"Get Food Allergens",28759
+2025-08-08T17:57:43.123163Z,"Get Allergic Reactions Allergens",45987
+2025-08-08T17:57:43.158144Z,"Get Current Visit of Patient",805892
+2025-08-08T17:57:43.185922Z,"Get Visits of Patient",30773
+2025-08-08T17:57:43.364425Z,"Select Location",1140
+2025-08-08T17:57:43.366483Z,"Get Address Template",1428
+2025-08-08T17:57:43.369359Z,"Get Relationship Types",5960
+2025-08-08T17:57:43.378598Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:43.380050Z,"Get Module Information",1237
+2025-08-08T17:57:43.382765Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:43.385235Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:43.387780Z,"Get Identifier Source",1233
+2025-08-08T17:57:43.390818Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:43.397602Z,"Get Visits",2799
+2025-08-08T17:57:43.401883Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:43.404387Z,"Get Identifier Source",0
+2025-08-08T17:57:43.407959Z,"Get Queue Entry",29
+2025-08-08T17:57:43.890384Z,"Get locations",41279
+2025-08-08T17:57:43.900862Z,"Get Observation Tree Details",4988
+2025-08-08T17:57:43.930621Z,"Get Active Visits of Patient",584
+2025-08-08T17:57:43.932539Z,"Search for Drug",14
+2025-08-08T17:57:43.934346Z,"Search for Drug",14
+2025-08-08T17:57:43.946606Z,"Get Observation Tree Details",10945
+2025-08-08T17:57:43.950564Z,"Get Observation Tree Details",190
+2025-08-08T17:57:43.961031Z,"Save Drug Order",1748
+2025-08-08T17:57:43.967631Z,"Get Lab Results of Patient",45165
+2025-08-08T17:57:43.973477Z,"Get Concept",0
+2025-08-08T17:57:43.978543Z,"Get Concept",0
+2025-08-08T17:57:43.982993Z,"Get Concept",0
+2025-08-08T17:57:43.987562Z,"Get Concept",0
+2025-08-08T17:57:43.992618Z,"Get Concept",0
+2025-08-08T17:57:43.997916Z,"Get Concept",0
+2025-08-08T17:57:44.002828Z,"Get Concept",0
+2025-08-08T17:57:44.008556Z,"Get Concept",0
+2025-08-08T17:57:44.009427Z,"Select Location",1140
+2025-08-08T17:57:44.010623Z,"Get Address Template",1428
+2025-08-08T17:57:44.012764Z,"Get Relationship Types",5960
+2025-08-08T17:57:44.013795Z,"Get Concept",0
+2025-08-08T17:57:44.019923Z,"Get Concept",0
+2025-08-08T17:57:44.020505Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:44.021709Z,"Get Module Information",1237
+2025-08-08T17:57:44.024588Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:44.027116Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:44.027349Z,"Get Concept",0
+2025-08-08T17:57:44.029997Z,"Get Identifier Source",1233
+2025-08-08T17:57:44.033043Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:44.034227Z,"Get Concept",0
+2025-08-08T17:57:44.039725Z,"Get Concept",0
+2025-08-08T17:57:44.040359Z,"Get Visits",2799
+2025-08-08T17:57:44.045334Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:44.047332Z,"Get Concept",0
+2025-08-08T17:57:44.048182Z,"Get Identifier Source",0
+2025-08-08T17:57:44.052200Z,"Get Queue Entry",29
+2025-08-08T17:57:44.052326Z,"Get Concept",0
+2025-08-08T17:57:44.057400Z,"Get Concept",0
+2025-08-08T17:57:44.057666Z,"Get Patient Summary Data",3283
+2025-08-08T17:57:44.063549Z,"Get Concept",0
+2025-08-08T17:57:44.065294Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:44.067834Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:44.069839Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:44.071888Z,"Get Concept",0
+2025-08-08T17:57:44.076289Z,"Get the status of patient death",49
+2025-08-08T17:57:44.076682Z,"Get Concept",0
+2025-08-08T17:57:44.079347Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:44.081385Z,"Get Concept",0
+2025-08-08T17:57:44.086252Z,"Get Concept",0
+2025-08-08T17:57:44.090733Z,"Get Concept",0
+2025-08-08T17:57:44.096472Z,"Get Concept",0
+2025-08-08T17:57:44.104597Z,"Get Concept",0
+2025-08-08T17:57:44.112140Z,"Get Patient Observations",81196
+2025-08-08T17:57:44.115008Z,"Get Concept",0
+2025-08-08T17:57:44.121732Z,"Get Concept",0
+2025-08-08T17:57:44.128875Z,"Get Concept",0
+2025-08-08T17:57:44.135670Z,"Get Concept",0
+2025-08-08T17:57:44.140501Z,"Get Patient Observations",65467
+2025-08-08T17:57:44.154326Z,"Get Patient Observations",16217
+2025-08-08T17:57:44.162210Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:44.183292Z,"Get Patient Conditions",13321
+2025-08-08T17:57:44.201228Z,"Get Active Orders",55551
+2025-08-08T17:57:44.330520Z,"Get Visit Types",1097
+2025-08-08T17:57:44.336290Z,"Get Locations That Support Visits",2180
+2025-08-08T17:57:44.341964Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:57:44.347859Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:57:44.350570Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:44.359011Z,"Get Visits",2799
+2025-08-08T17:57:44.367651Z,"Submit Visit Form",1238
+2025-08-08T17:57:44.375276Z,"Submit Appointment StatusChange",1213
+2025-08-08T17:57:44.504996Z,"Get Active Visits of Patient",2199
+2025-08-08T17:57:44.508552Z,"Get isVisitsEnabled",0
+2025-08-08T17:57:44.513069Z,"Get all the constraints on the vital concepts",0
+2025-08-08T17:57:44.573496Z,"Get Patient Observations",129435
+2025-08-08T17:57:44.609261Z,"Get Vitals concept reference ranges",0
+2025-08-08T17:57:44.617202Z,"Get Specific Visit Details",2185
+2025-08-08T17:57:44.893395Z,"Select Location",1140
+2025-08-08T17:57:44.897849Z,"Get Address Template",1428
+2025-08-08T17:57:44.904593Z,"Get Relationship Types",5960
+2025-08-08T17:57:44.921148Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:44.925283Z,"Get Module Information",1237
+2025-08-08T17:57:44.930348Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:44.934210Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:44.939043Z,"Get Identifier Source",1233
+2025-08-08T17:57:44.945256Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:44.955828Z,"Get Visits",3493
+2025-08-08T17:57:44.961482Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:44.964423Z,"Get Identifier Source",0
+2025-08-08T17:57:44.968395Z,"Get Queue Entry",29
+2025-08-08T17:57:45.957153Z,"Get all patient lists",31754
+2025-08-08T17:57:45.968111Z,"Get all patient lists",29
+2025-08-08T17:57:46.049418Z,"Get all patient lists",31802
+2025-08-08T17:57:46.418584Z,"Get Visit Types",1097
+2025-08-08T17:57:46.483805Z,"Get Current Visit of Patient",105487
+2025-08-08T17:57:46.512705Z,"Select Location",1140
+2025-08-08T17:57:46.514300Z,"Get Address Template",1428
+2025-08-08T17:57:46.516776Z,"Get Relationship Types",5960
+2025-08-08T17:57:46.525470Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:46.527401Z,"Get Module Information",1237
+2025-08-08T17:57:46.527422Z,"Get Visits of Patient",115848
+2025-08-08T17:57:46.530290Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:46.531715Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:57:46.532897Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:46.535679Z,"Get Identifier Source",1233
+2025-08-08T17:57:46.544651Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:46.544980Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:46.547058Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:46.553031Z,"Get Visits",3493
+2025-08-08T17:57:46.557961Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:46.560804Z,"Get Identifier Source",0
+2025-08-08T17:57:46.564381Z,"Get Queue Entry",29
+2025-08-08T17:57:47.674338Z,"Get Transfer Locations configuration data",0
+2025-08-08T17:57:47.693498Z,"Get Transferable locations",4651
+2025-08-08T17:57:47.720648Z,"Save Ward Encounter",2058
+2025-08-08T17:57:47.979890Z,"Get Active Visits of Patient",580
+2025-08-08T17:57:47.991826Z,"Get Specific Visit Details",566
+2025-08-08T17:57:47.996436Z,"Get the details of a orderType",533
+2025-08-08T17:57:48.011708Z,"Get all Lab order details",28680
+2025-08-08T17:57:48.013629Z,"Get Module Information",0
+2025-08-08T17:57:48.035041Z,"Add a lab order",1715
+2025-08-08T17:57:48.149429Z,"Save an Allergy",1535
+2025-08-08T17:57:48.158022Z,"Login",1140
+2025-08-08T17:57:48.196975Z,"Get Active Visits of Patient",584
+2025-08-08T17:57:48.204696Z,"Get Specific Visit Details",570
+2025-08-08T17:57:48.230615Z,"Get All Form Encounters",20083
+2025-08-08T17:57:48.236208Z,"Get All Forms",5203
+2025-08-08T17:57:48.901780Z,"Select Location",1140
+2025-08-08T17:57:48.906238Z,"Get Address Template",1428
+2025-08-08T17:57:48.912838Z,"Get Relationship Types",5960
+2025-08-08T17:57:48.929280Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:48.932335Z,"Get Module Information",1237
+2025-08-08T17:57:48.936538Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:48.940756Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:48.944528Z,"Get Identifier Source",1233
+2025-08-08T17:57:48.948651Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:48.957829Z,"Get Visits",3493
+2025-08-08T17:57:48.962582Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:48.965424Z,"Get Identifier Source",0
+2025-08-08T17:57:48.967041Z,"Get Locations by Tag and Query",10667
+2025-08-08T17:57:48.969367Z,"Get Queue Entry",29
+2025-08-08T17:57:48.992299Z,"Get medication request encounters",3561
+2025-08-08T17:57:48.996512Z,"Get patient age",10
+2025-08-08T17:57:48.999036Z,"Get patient age",0
+2025-08-08T17:57:49.061695Z,"Create a patient list",1039
+2025-08-08T17:57:49.087296Z,"Get all patient lists",31754
+2025-08-08T17:57:49.179044Z,"Get locations",41279
+2025-08-08T17:57:49.205177Z,"Get Address Template",0
+2025-08-08T17:57:49.209389Z,"Get Patient Identifier Types",0
+2025-08-08T17:57:49.213213Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:49.215980Z,"Get Relationship Types",0
+2025-08-08T17:57:49.217935Z,"Get Module Information",0
+2025-08-08T17:57:49.220481Z,"Get Person Attribute Type",622
+2025-08-08T17:57:49.226318Z,"Get Auto Generation Options",0
+2025-08-08T17:57:49.227693Z,"Get Ordered Address Hierarchy Levels",2
+2025-08-08T17:57:49.231254Z,"Get Identifier Source",0
+2025-08-08T17:57:49.238294Z,"Get the status of patient death",0
+2025-08-08T17:57:49.246159Z,"Get patient identification photo",14
+2025-08-08T17:57:49.254473Z,"Get Patient Summary Data",0
+2025-08-08T17:57:49.260983Z,"Get Person Attributes",14
+2025-08-08T17:57:49.267318Z,"Get Patient Identifiers",202
+2025-08-08T17:57:49.273331Z,"Get Relationships of Person",14
+2025-08-08T17:57:49.666626Z,"Get Patients",110400
+2025-08-08T17:57:49.674079Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.677515Z,"Get patient identification photo",14
+2025-08-08T17:57:49.680166Z,"Get the status of patient death",49
+2025-08-08T17:57:49.683160Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.686479Z,"Get patient identification photo",14
+2025-08-08T17:57:49.688855Z,"Get the status of patient death",49
+2025-08-08T17:57:49.691786Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.694720Z,"Get patient identification photo",14
+2025-08-08T17:57:49.696703Z,"Get the status of patient death",49
+2025-08-08T17:57:49.699096Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.701585Z,"Get patient identification photo",14
+2025-08-08T17:57:49.703635Z,"Get the status of patient death",49
+2025-08-08T17:57:49.706358Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.709101Z,"Get patient identification photo",14
+2025-08-08T17:57:49.711275Z,"Get the status of patient death",49
+2025-08-08T17:57:49.714503Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.717568Z,"Get patient identification photo",14
+2025-08-08T17:57:49.719776Z,"Get the status of patient death",49
+2025-08-08T17:57:49.722627Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.725400Z,"Get patient identification photo",14
+2025-08-08T17:57:49.727597Z,"Get the status of patient death",49
+2025-08-08T17:57:49.730096Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.732932Z,"Get patient identification photo",14
+2025-08-08T17:57:49.735271Z,"Get the status of patient death",49
+2025-08-08T17:57:49.738232Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.741221Z,"Get patient identification photo",14
+2025-08-08T17:57:49.743433Z,"Get the status of patient death",49
+2025-08-08T17:57:49.746054Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.748737Z,"Get patient identification photo",14
+2025-08-08T17:57:49.750975Z,"Get the status of patient death",49
+2025-08-08T17:57:49.753706Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.756419Z,"Get patient identification photo",14
+2025-08-08T17:57:49.758639Z,"Get the status of patient death",49
+2025-08-08T17:57:49.761165Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.763930Z,"Get patient identification photo",14
+2025-08-08T17:57:49.766090Z,"Get the status of patient death",49
+2025-08-08T17:57:49.768559Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.771389Z,"Get patient identification photo",14
+2025-08-08T17:57:49.773465Z,"Get the status of patient death",49
+2025-08-08T17:57:49.776105Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.778806Z,"Get patient identification photo",14
+2025-08-08T17:57:49.780917Z,"Get the status of patient death",49
+2025-08-08T17:57:49.783413Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.786122Z,"Get patient identification photo",14
+2025-08-08T17:57:49.788287Z,"Get the status of patient death",49
+2025-08-08T17:57:49.790867Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.793552Z,"Get patient identification photo",14
+2025-08-08T17:57:49.795638Z,"Get the status of patient death",49
+2025-08-08T17:57:49.798040Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.801018Z,"Get patient identification photo",14
+2025-08-08T17:57:49.803243Z,"Get the status of patient death",49
+2025-08-08T17:57:49.805717Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.808365Z,"Get patient identification photo",14
+2025-08-08T17:57:49.810293Z,"Get the status of patient death",49
+2025-08-08T17:57:49.812630Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.815248Z,"Get patient identification photo",14
+2025-08-08T17:57:49.817351Z,"Get the status of patient death",49
+2025-08-08T17:57:49.819729Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.822353Z,"Get patient identification photo",14
+2025-08-08T17:57:49.824360Z,"Get the status of patient death",49
+2025-08-08T17:57:49.826683Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.829223Z,"Get patient identification photo",14
+2025-08-08T17:57:49.831121Z,"Get the status of patient death",49
+2025-08-08T17:57:49.833311Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.835753Z,"Get patient identification photo",14
+2025-08-08T17:57:49.837569Z,"Get the status of patient death",49
+2025-08-08T17:57:49.839763Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.842229Z,"Get patient identification photo",14
+2025-08-08T17:57:49.844207Z,"Get the status of patient death",49
+2025-08-08T17:57:49.846495Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.848993Z,"Get patient identification photo",14
+2025-08-08T17:57:49.850833Z,"Get the status of patient death",49
+2025-08-08T17:57:49.853003Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.855474Z,"Get patient identification photo",14
+2025-08-08T17:57:49.857397Z,"Get the status of patient death",49
+2025-08-08T17:57:49.859767Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.862324Z,"Get patient identification photo",14
+2025-08-08T17:57:49.864260Z,"Get the status of patient death",49
+2025-08-08T17:57:49.866564Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.869052Z,"Get patient identification photo",14
+2025-08-08T17:57:49.870953Z,"Get the status of patient death",49
+2025-08-08T17:57:49.873136Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.875653Z,"Get patient identification photo",14
+2025-08-08T17:57:49.877510Z,"Get the status of patient death",49
+2025-08-08T17:57:49.879688Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.882162Z,"Get patient identification photo",14
+2025-08-08T17:57:49.884092Z,"Get the status of patient death",49
+2025-08-08T17:57:49.886463Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.888997Z,"Get patient identification photo",14
+2025-08-08T17:57:49.890786Z,"Get the status of patient death",49
+2025-08-08T17:57:49.893069Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.895577Z,"Get patient identification photo",14
+2025-08-08T17:57:49.897449Z,"Get the status of patient death",49
+2025-08-08T17:57:49.899663Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.901998Z,"Get patient identification photo",14
+2025-08-08T17:57:49.903788Z,"Get the status of patient death",49
+2025-08-08T17:57:49.905987Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.908382Z,"Get patient identification photo",14
+2025-08-08T17:57:49.910224Z,"Get the status of patient death",49
+2025-08-08T17:57:49.912427Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.914975Z,"Get patient identification photo",14
+2025-08-08T17:57:49.916843Z,"Get the status of patient death",49
+2025-08-08T17:57:49.919035Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.921478Z,"Get patient identification photo",14
+2025-08-08T17:57:49.923263Z,"Get the status of patient death",49
+2025-08-08T17:57:49.925444Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.927858Z,"Get patient identification photo",14
+2025-08-08T17:57:49.929711Z,"Get the status of patient death",49
+2025-08-08T17:57:49.938168Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.940776Z,"Get patient identification photo",14
+2025-08-08T17:57:49.942749Z,"Get the status of patient death",49
+2025-08-08T17:57:49.973315Z,"Get Patient Summary Data",1193
+2025-08-08T17:57:49.976682Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:49.978889Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:49.980648Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:49.982846Z,"Get the status of patient death",49
+2025-08-08T17:57:49.985433Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:50.030050Z,"Get Patient Observations",168173
+2025-08-08T17:57:50.073251Z,"Get Patient Observations",163087
+2025-08-08T17:57:50.094478Z,"Get Patient Observations",39755
+2025-08-08T17:57:50.100445Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:50.158937Z,"Get Patient Conditions",50416
+2025-08-08T17:57:50.163709Z,"Get Active Orders",14
+2025-08-08T17:57:50.754616Z,"Get locations",41279
+2025-08-08T17:57:50.759936Z,"Get Locations Search Set",1057
+2025-08-08T17:57:50.764263Z,"Change the session location",1344
+2025-08-08T17:57:50.769213Z,"Get Admission Location Info",1812
+2025-08-08T17:57:50.784383Z,"Get Admission Info",14
+2025-08-08T17:57:50.805398Z,"Get Inpatient Request",41513
+2025-08-08T17:57:51.576767Z,"Submit Visit Form",1237
+2025-08-08T17:57:51.620888Z,"Get Current Visit of Patient",86630
+2025-08-08T17:57:51.652080Z,"Get Visits of Patient",96991
+2025-08-08T17:57:51.976420Z,"Get Address Template",0
+2025-08-08T17:57:51.985105Z,"Get Patient Identifier Types",0
+2025-08-08T17:57:51.991970Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:51.997562Z,"Get Relationship Types",0
+2025-08-08T17:57:52.000482Z,"Get Module Information",0
+2025-08-08T17:57:52.003685Z,"Get Patient Allergy Intolerance",448
+2025-08-08T17:57:52.005338Z,"Get Person Attribute Type",622
+2025-08-08T17:57:52.016156Z,"Get Auto Generation Options",0
+2025-08-08T17:57:52.018385Z,"Get Ordered Address Hierarchy Levels",2
+2025-08-08T17:57:52.023277Z,"Get Identifier Source",0
+2025-08-08T17:57:52.037688Z,"Get Specific Medication Requests",3574
+2025-08-08T17:57:52.043648Z,"Get Encounter With Visit and Diagnoses",210
+2025-08-08T17:57:52.048260Z,"Get All Providers",1359
+2025-08-08T17:57:52.077877Z,"Get Patient Conditions",27560
+2025-08-08T17:57:52.092553Z,"Get patient list details",689
+2025-08-08T17:57:52.095136Z,"Fetch members of patient list",14
+2025-08-08T17:57:52.101068Z,"Login",1140
+2025-08-08T17:57:52.953347Z,"Get Visit Types",1097
+2025-08-08T17:57:52.963774Z,"Get Locations That Support Visits",2180
+2025-08-08T17:57:52.979870Z,"Get Program Enrollments of Patient",4684
+2025-08-08T17:57:52.987182Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:57:52.990198Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:53.001242Z,"Submit Visit Form",1234
+2025-08-08T17:57:53.005889Z,"Get patient identification photo",14
+2025-08-08T17:57:53.008611Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:53.013196Z,"Get Patient Summary Data",1179
+2025-08-08T17:57:53.018894Z,"Get Active Visits of Patient",580
+2025-08-08T17:57:53.023952Z,"Get Queue Entry",29
+2025-08-08T17:57:53.026375Z,"Get the status of patient death",49
+2025-08-08T17:57:53.027422Z,"Get queue entry number",97
+2025-08-08T17:57:53.043950Z,"Get all active Lab orders",1327
+2025-08-08T17:57:53.045046Z,"Submit visit queue entry",7797
+2025-08-08T17:57:53.046590Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:57:53.055290Z,"Get Queue Entry",8936
+2025-08-08T17:57:53.093789Z,"Get Lab Orders by full filler status",28794
+2025-08-08T17:57:53.097139Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:57:53.112740Z,"Get locations",41279
+2025-08-08T17:57:53.247108Z,"Get Active Visits of Patient",0
+2025-08-08T17:57:53.254177Z,"Get Specific Visit Details",0
+2025-08-08T17:57:53.261197Z,"Get Clinical Form by UUID",1870
+2025-08-08T17:57:53.266571Z,"Get Patient Summary Data",0
+2025-08-08T17:57:53.268409Z,"Get Encounter Roles",187
+2025-08-08T17:57:53.275884Z,"Get Latest FHIR Encounter",1927
+2025-08-08T17:57:53.282496Z,"Get Encounter By UUID",1833
+2025-08-08T17:57:53.819652Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:53.830340Z,"Get patient admission note",14
+2025-08-08T17:57:53.838428Z,"Get Beds for Patient",0
+2025-08-08T17:57:53.858907Z,"Save Ward Encounter",1767
+2025-08-08T17:57:54.178987Z,"Get Patient Conditions",21827
+2025-08-08T17:57:54.182452Z,"Select Location",1140
+2025-08-08T17:57:54.184223Z,"Get Address Template",1428
+2025-08-08T17:57:54.187127Z,"Get Relationship Types",5960
+2025-08-08T17:57:54.196217Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:54.197743Z,"Get Module Information",1237
+2025-08-08T17:57:54.200359Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:54.202641Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:54.205222Z,"Get Identifier Source",1233
+2025-08-08T17:57:54.208017Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:54.219459Z,"Get Visits",4876
+2025-08-08T17:57:54.223716Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:54.226085Z,"Get Identifier Source",0
+2025-08-08T17:57:54.235267Z,"Get Queue Entry",8936
+2025-08-08T17:57:54.238938Z,"Get Patient Summary Data",1183
+2025-08-08T17:57:54.241744Z,"Get Active Visits of Patient",14
+2025-08-08T17:57:54.243446Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:54.244669Z,"Get isVisitsEnabled",16
+2025-08-08T17:57:54.246542Z,"Get the status of patient death",49
+2025-08-08T17:57:54.248638Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:57:54.284991Z,"Get Patient Observations",165531
+2025-08-08T17:57:54.302704Z,"Edit patient details",1829
+2025-08-08T17:57:54.307681Z,"Login",1140
+2025-08-08T17:57:54.332854Z,"Get Patient Observations",181923
+2025-08-08T17:57:54.356389Z,"Get Patient Observations",61068
+2025-08-08T17:57:54.361699Z,"Get Visit Queue Entry",14
+2025-08-08T17:57:54.387711Z,"Get Patient Conditions",26263
+2025-08-08T17:57:54.392953Z,"Get Active Orders",14
+2025-08-08T17:57:54.396292Z,"End Visit",1264
+2025-08-08T17:57:54.398478Z,"Get Visit Types",0
+2025-08-08T17:57:54.402268Z,"Get Locations That Support Visits",0
+2025-08-08T17:57:54.409078Z,"Submit Appointment StatusChange",1213
+2025-08-08T17:57:54.410736Z,"Get All Appointment Services(full)",0
+2025-08-08T17:57:54.412772Z,"Get all appointments for a specific day",2
+2025-08-08T17:57:54.420210Z,"Get all appointment summaries",1719
+2025-08-08T17:57:54.429340Z,"Get Appointment By Status",4589
+2025-08-08T17:57:54.431574Z,"Get Appointment By Status",2
+2025-08-08T17:57:54.433488Z,"Get Appointment By Status",2
+2025-08-08T17:57:54.435603Z,"Get Appointment By Status",2
+2025-08-08T17:57:54.437117Z,"Get all default appointment services",0
+2025-08-08T17:57:54.449680Z,"Get all visits of the given location with date",6031
+2025-08-08T17:57:54.454605Z,"Login",1140
+2025-08-08T17:57:54.663396Z,"Get Order Types",443
+2025-08-08T17:57:54.685008Z,"Get Active Orders",4171
+2025-08-08T17:57:55.090557Z,"Get Patient Summary Data",1185
+2025-08-08T17:57:55.113227Z,"Get Order Entry Config",26242
+2025-08-08T17:57:55.125496Z,"Get ValueSet by UUID",1660
+2025-08-08T17:57:55.133878Z,"Get ValueSet by UUID",1285
+2025-08-08T17:57:55.150978Z,"Get Medication Request by UUID",1745
+2025-08-08T17:57:55.152919Z,"Get Medication by UUID",879
+2025-08-08T17:57:55.156174Z,"Get All Providers",0
+2025-08-08T17:57:55.159109Z,"Search Medication by Code",4395
+2025-08-08T17:57:55.166743Z,"Get Visit Types",1097
+2025-08-08T17:57:55.180192Z,"Get Specific Medication Requests",3574
+2025-08-08T17:57:55.183870Z,"Get patient identification photo",14
+2025-08-08T17:57:55.186406Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:57:55.195863Z,"Get Active Visits of Patient",1212
+2025-08-08T17:57:55.201301Z,"Get Visit Queue Entry",0
+2025-08-08T17:57:55.204242Z,"Get the status of patient death",49
+2025-08-08T17:57:55.212238Z,"Get Current Visit of Patient",114972
+2025-08-08T17:57:55.239487Z,"Get Visits of Patient",56573
+2025-08-08T17:57:55.242322Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:57:55.246543Z,"Get Visit Queue Entry",0
+2025-08-08T17:57:55.248215Z,"Get Appointments of a Patient",2
+2025-08-08T17:57:55.322470Z,"Get locations",41279
+2025-08-08T17:57:55.491285Z,"Get locations",41279
+2025-08-08T17:57:56.066048Z,"Get service concept set",48
+2025-08-08T17:57:56.082919Z,"Get Concept",7419
+2025-08-08T17:57:56.098927Z,"Submit new Service queue",2208
+2025-08-08T17:57:58.124761Z,"Select Location",1140
+2025-08-08T17:57:58.129106Z,"Get Address Template",1428
+2025-08-08T17:57:58.131356Z,"Update full filler status",0
+2025-08-08T17:57:58.134060Z,"Get Relationship Types",5960
+2025-08-08T17:57:58.144256Z,"Get all active Lab orders",1334
+2025-08-08T17:57:58.145482Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:57:58.147043Z,"Get Module Information",1237
+2025-08-08T17:57:58.150223Z,"Get Patient Identifier Types",971
+2025-08-08T17:57:58.153220Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:57:58.154956Z,"Get Lab Orders by full filler status",1334
+2025-08-08T17:57:58.157719Z,"Get Identifier Source",1233
+2025-08-08T17:57:58.162375Z,"Get Locations by Tag and Query",233
+2025-08-08T17:57:58.173335Z,"Get Visits",4182
+2025-08-08T17:57:58.178550Z,"Get Auto Generation Options",2298
+2025-08-08T17:57:58.181301Z,"Get Identifier Source",0
+2025-08-08T17:57:58.191899Z,"Get Queue Entry",8936
+2025-08-08T17:57:58.210196Z,"Get Lab Orders by full filler status",28794
+2025-08-08T17:57:58.213673Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:57:58.303824Z,"Save a clinical form",1833
+2025-08-08T17:57:58.308754Z,"Get Active Visits of Patient",0
+2025-08-08T17:57:58.313173Z,"Get Specific Visit Details",0
+2025-08-08T17:57:58.892029Z,"Save Ward Encounter",1767
+2025-08-08T17:57:58.936955Z,"End Visit",2397
+2025-08-08T17:57:58.942980Z,"Login",1140
+2025-08-08T17:57:59.146372Z,"Submit transition request",1671
+2025-08-08T17:57:59.166438Z,"Get Queue Entry",18956
+2025-08-08T17:57:59.191538Z,"End Visit",1260
+2025-08-08T17:57:59.195235Z,"Get Patient Conditions",21827
+2025-08-08T17:57:59.204405Z,"Get Current Visit of Patient",11287
+2025-08-08T17:57:59.216708Z,"Get Visits of Patient",21648
+2025-08-08T17:57:59.221610Z,"Login",1140
+2025-08-08T17:57:59.488005Z,"Get Patient Observations",181923
+2025-08-08T17:57:59.518634Z,"Get Patient Observations",61068
+2025-08-08T17:57:59.704841Z,"Get Active Visits of Patient",583
+2025-08-08T17:57:59.708481Z,"Search for Drug",14
+2025-08-08T17:57:59.711188Z,"Search for Drug",14
+2025-08-08T17:57:59.746120Z,"Save Drug Order",1747
+2025-08-08T17:57:59.977688Z,"Get locations",41279
+2025-08-08T17:58:00.249888Z,"Get locations",41279
+2025-08-08T17:58:00.259070Z,"Submit Visit Form",1241
+2025-08-08T17:58:00.266390Z,"Dispense medication form submission",1955
+2025-08-08T17:58:00.296011Z,"Get Current Visit of Patient",94230
+2025-08-08T17:58:00.321764Z,"Get medication request encounters",8663
+2025-08-08T17:58:00.323643Z,"Get Visits of Patient",49583
+2025-08-08T17:58:00.324918Z,"Select Location",1140
+2025-08-08T17:58:00.326185Z,"Get Address Template",1428
+2025-08-08T17:58:00.328350Z,"Get Relationship Types",5960
+2025-08-08T17:58:00.335318Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:00.336532Z,"Get Module Information",1237
+2025-08-08T17:58:00.338996Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:00.340773Z,"Get Medication Request by UUID",0
+2025-08-08T17:58:00.341119Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:00.343518Z,"Get Identifier Source",1233
+2025-08-08T17:58:00.346293Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:00.355628Z,"Get Visits",4189
+2025-08-08T17:58:00.359925Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:00.362340Z,"Get Identifier Source",0
+2025-08-08T17:58:00.365754Z,"Get Queue Entry",29
+2025-08-08T17:58:00.370982Z,"Get Patient Summary Data",3283
+2025-08-08T17:58:00.377448Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:00.377723Z,"Get Specific Medication Requests",5648
+2025-08-08T17:58:00.379573Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:00.381188Z,"Get isVisitsEnabled",16
+2025-08-08T17:58:00.386115Z,"Get the status of patient death",49
+2025-08-08T17:58:00.388258Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:58:00.451595Z,"Get Patient Observations",147933
+2025-08-08T17:58:00.489512Z,"Get Patient Observations",119194
+2025-08-08T17:58:00.494323Z,"Select Location",1140
+2025-08-08T17:58:00.495804Z,"Get Address Template",1428
+2025-08-08T17:58:00.498188Z,"Get Relationship Types",5960
+2025-08-08T17:58:00.506043Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:00.507617Z,"Get Module Information",1237
+2025-08-08T17:58:00.510314Z,"Get Patient Observations",29227
+2025-08-08T17:58:00.510854Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:00.513225Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:00.515849Z,"Get Identifier Source",1233
+2025-08-08T17:58:00.518725Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:00.519219Z,"Get Visit Queue Entry",14
+2025-08-08T17:58:00.528799Z,"Get Visits",4189
+2025-08-08T17:58:00.533615Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:00.536318Z,"Get Identifier Source",0
+2025-08-08T17:58:00.540253Z,"Get Queue Entry",29
+2025-08-08T17:58:00.558097Z,"Get Patient Conditions",32162
+2025-08-08T17:58:00.566103Z,"Get Active Orders",14
+2025-08-08T17:58:01.209089Z,"Search for Condition",107
+2025-08-08T17:58:01.235212Z,"Get all patient lists",31754
+2025-08-08T17:58:01.241842Z,"Get all patient lists",29
+2025-08-08T17:58:01.275908Z,"Get all patient lists",31802
+2025-08-08T17:58:01.345395Z,"Get Visits of Patient",0
+2025-08-08T17:58:01.441410Z,"Get Patient Encounters",159217
+2025-08-08T17:58:01.461553Z,"Get Lab Results of Patient",44539
+2025-08-08T17:58:01.469684Z,"Get Concept",20084
+2025-08-08T17:58:01.475528Z,"Get Concept",9125
+2025-08-08T17:58:01.482014Z,"Get Concept",12109
+2025-08-08T17:58:01.488092Z,"Get Concept",12182
+2025-08-08T17:58:01.494080Z,"Get Concept",8522
+2025-08-08T17:58:01.502175Z,"Get Concept",18399
+2025-08-08T17:58:01.510267Z,"Get Concept",19038
+2025-08-08T17:58:01.517102Z,"Get Concept",12276
+2025-08-08T17:58:01.523716Z,"Get Concept",13996
+2025-08-08T17:58:01.529364Z,"Get Concept",10098
+2025-08-08T17:58:01.535311Z,"Get Concept",15533
+2025-08-08T17:58:01.539757Z,"Get Concept",9143
+2025-08-08T17:58:01.545333Z,"Get Concept",13808
+2025-08-08T17:58:01.550418Z,"Get Concept",10999
+2025-08-08T17:58:01.556237Z,"Get Concept",0
+2025-08-08T17:58:01.561273Z,"Get Concept",0
+2025-08-08T17:58:01.566097Z,"Get Concept",0
+2025-08-08T17:58:01.571971Z,"Get Concept",0
+2025-08-08T17:58:01.577172Z,"Get Concept",0
+2025-08-08T17:58:01.582811Z,"Get Concept",0
+2025-08-08T17:58:01.589249Z,"Get Concept",0
+2025-08-08T17:58:01.593734Z,"Get Concept",0
+2025-08-08T17:58:01.600232Z,"Get Concept",0
+2025-08-08T17:58:01.604971Z,"Get Concept",0
+2025-08-08T17:58:01.611955Z,"Get Concept",0
+2025-08-08T17:58:01.616237Z,"Get Concept",0
+2025-08-08T17:58:02.055710Z,"Generate OMRS Identifier",24
+2025-08-08T17:58:02.095771Z,"Send Patient Registration Request",1870
+2025-08-08T17:58:02.222351Z,"Search for Condition",14
+2025-08-08T17:58:03.237659Z,"Get specific encounter details",793
+2025-08-08T17:58:03.243140Z,"Save Conditions",1068
+2025-08-08T17:58:03.244212Z,"Get Alkaline concept details",1387
+2025-08-08T17:58:03.269821Z,"Update the specific encounter",1930
+2025-08-08T17:58:03.285109Z,"Update the Lab Order Completion",2773
+2025-08-08T17:58:03.291604Z,"Update full filler status",0
+2025-08-08T17:58:03.294701Z,"Get all active Lab orders",14
+2025-08-08T17:58:03.297300Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:03.348381Z,"Get Lab Orders by full filler status",30159
+2025-08-08T17:58:03.351506Z,"Get Lab Orders by full filler status",0
+2025-08-08T17:58:03.383541Z,"Get Patient Summary Data",0
+2025-08-08T17:58:03.391603Z,"Get ValueSet by UUID",2315
+2025-08-08T17:58:03.395224Z,"Get patient identification photo",0
+2025-08-08T17:58:03.397837Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:03.403603Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:03.406482Z,"Get the status of patient death",0
+2025-08-08T17:58:03.629639Z,"Get Visits With Diagnoses and Notes (new endpoint)",3673
+2025-08-08T17:58:03.653015Z,"Get Patients",113383
+2025-08-08T17:58:03.681348Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.685634Z,"Get patient identification photo",14
+2025-08-08T17:58:03.689179Z,"Get the status of patient death",49
+2025-08-08T17:58:03.692728Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.697482Z,"Get patient identification photo",14
+2025-08-08T17:58:03.700243Z,"Get the status of patient death",49
+2025-08-08T17:58:03.703299Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.706726Z,"Get patient identification photo",14
+2025-08-08T17:58:03.709146Z,"Get the status of patient death",49
+2025-08-08T17:58:03.712161Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.715616Z,"Get patient identification photo",14
+2025-08-08T17:58:03.718046Z,"Get the status of patient death",49
+2025-08-08T17:58:03.720968Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.724174Z,"Get patient identification photo",14
+2025-08-08T17:58:03.727885Z,"Get the status of patient death",49
+2025-08-08T17:58:03.730963Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.734646Z,"Get patient identification photo",14
+2025-08-08T17:58:03.737088Z,"Get the status of patient death",49
+2025-08-08T17:58:03.740029Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.743008Z,"Get patient identification photo",14
+2025-08-08T17:58:03.745587Z,"Get the status of patient death",49
+2025-08-08T17:58:03.749034Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.751899Z,"Get patient identification photo",14
+2025-08-08T17:58:03.754426Z,"Get the status of patient death",49
+2025-08-08T17:58:03.757100Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.760197Z,"Get patient identification photo",14
+2025-08-08T17:58:03.762733Z,"Get the status of patient death",49
+2025-08-08T17:58:03.765150Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.768102Z,"Get patient identification photo",14
+2025-08-08T17:58:03.770310Z,"Get the status of patient death",49
+2025-08-08T17:58:03.772810Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.775400Z,"Get patient identification photo",14
+2025-08-08T17:58:03.777598Z,"Get the status of patient death",49
+2025-08-08T17:58:03.780491Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.783149Z,"Get patient identification photo",14
+2025-08-08T17:58:03.785231Z,"Get the status of patient death",49
+2025-08-08T17:58:03.787757Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.790468Z,"Get patient identification photo",14
+2025-08-08T17:58:03.792571Z,"Get the status of patient death",49
+2025-08-08T17:58:03.795039Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.797602Z,"Get patient identification photo",14
+2025-08-08T17:58:03.799488Z,"Get the status of patient death",49
+2025-08-08T17:58:03.801747Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.804341Z,"Get patient identification photo",14
+2025-08-08T17:58:03.806379Z,"Get the status of patient death",49
+2025-08-08T17:58:03.808841Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.811353Z,"Get patient identification photo",14
+2025-08-08T17:58:03.813253Z,"Get the status of patient death",49
+2025-08-08T17:58:03.815464Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.817930Z,"Get patient identification photo",14
+2025-08-08T17:58:03.819773Z,"Get the status of patient death",49
+2025-08-08T17:58:03.821993Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.824404Z,"Get patient identification photo",14
+2025-08-08T17:58:03.826357Z,"Get the status of patient death",49
+2025-08-08T17:58:03.828725Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.831080Z,"Get patient identification photo",14
+2025-08-08T17:58:03.832976Z,"Get the status of patient death",49
+2025-08-08T17:58:03.835196Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.837677Z,"Get patient identification photo",14
+2025-08-08T17:58:03.839577Z,"Get the status of patient death",49
+2025-08-08T17:58:03.842111Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.844689Z,"Get patient identification photo",14
+2025-08-08T17:58:03.846631Z,"Get the status of patient death",49
+2025-08-08T17:58:03.848989Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.851548Z,"Get patient identification photo",14
+2025-08-08T17:58:03.853648Z,"Get the status of patient death",49
+2025-08-08T17:58:03.855904Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.858392Z,"Get patient identification photo",14
+2025-08-08T17:58:03.860199Z,"Get the status of patient death",49
+2025-08-08T17:58:03.862443Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.864923Z,"Get patient identification photo",14
+2025-08-08T17:58:03.866763Z,"Get the status of patient death",49
+2025-08-08T17:58:03.868976Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.871509Z,"Get patient identification photo",14
+2025-08-08T17:58:03.873380Z,"Get the status of patient death",49
+2025-08-08T17:58:03.875581Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.877954Z,"Get patient identification photo",14
+2025-08-08T17:58:03.879746Z,"Get the status of patient death",49
+2025-08-08T17:58:03.881893Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.884312Z,"Get patient identification photo",14
+2025-08-08T17:58:03.886117Z,"Get the status of patient death",49
+2025-08-08T17:58:03.888273Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.890670Z,"Get patient identification photo",14
+2025-08-08T17:58:03.892596Z,"Get the status of patient death",49
+2025-08-08T17:58:03.894779Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.897193Z,"Get patient identification photo",14
+2025-08-08T17:58:03.899025Z,"Get the status of patient death",49
+2025-08-08T17:58:03.901178Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.903700Z,"Get patient identification photo",14
+2025-08-08T17:58:03.905612Z,"Get the status of patient death",49
+2025-08-08T17:58:03.907736Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.910254Z,"Get patient identification photo",14
+2025-08-08T17:58:03.912046Z,"Get the status of patient death",49
+2025-08-08T17:58:03.914183Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.916722Z,"Get patient identification photo",14
+2025-08-08T17:58:03.918429Z,"Get the status of patient death",49
+2025-08-08T17:58:03.920575Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.923086Z,"Get patient identification photo",14
+2025-08-08T17:58:03.925005Z,"Get the status of patient death",49
+2025-08-08T17:58:03.927097Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.929600Z,"Get patient identification photo",14
+2025-08-08T17:58:03.931406Z,"Get the status of patient death",49
+2025-08-08T17:58:03.933579Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.935998Z,"Get patient identification photo",14
+2025-08-08T17:58:03.937809Z,"Get the status of patient death",49
+2025-08-08T17:58:03.940048Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.942541Z,"Get patient identification photo",14
+2025-08-08T17:58:03.944378Z,"Get the status of patient death",49
+2025-08-08T17:58:03.946484Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.948944Z,"Get patient identification photo",14
+2025-08-08T17:58:03.950812Z,"Get the status of patient death",49
+2025-08-08T17:58:03.952992Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:03.955494Z,"Get patient identification photo",14
+2025-08-08T17:58:03.957411Z,"Get the status of patient death",49
+2025-08-08T17:58:03.959203Z,"Get All Appointment Services(full)",1297
+2025-08-08T17:58:03.961048Z,"Get all appointments for a specific day",2
+2025-08-08T17:58:03.968033Z,"Get all appointment summaries",1719
+2025-08-08T17:58:03.977413Z,"Get Appointment By Status",4589
+2025-08-08T17:58:03.979428Z,"Get Appointment By Status",2
+2025-08-08T17:58:03.981427Z,"Get Appointment By Status",2
+2025-08-08T17:58:03.983388Z,"Get Appointment By Status",2
+2025-08-08T17:58:03.985001Z,"Get all default appointment services",1085
+2025-08-08T17:58:03.995625Z,"Get all visits of the given location with date",6653
+2025-08-08T17:58:04.103090Z,"Get Patient Summary Data",1208
+2025-08-08T17:58:04.107975Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:04.110988Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:04.113239Z,"Get isVisitsEnabled",16
+2025-08-08T17:58:04.116023Z,"Get the status of patient death",49
+2025-08-08T17:58:04.119069Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:58:04.120582Z,"Get Patient Observations",867
+2025-08-08T17:58:04.121771Z,"Get Patient Observations",750
+2025-08-08T17:58:04.122801Z,"Get Patient Observations",594
+2025-08-08T17:58:04.127793Z,"Get Visit Queue Entry",14
+2025-08-08T17:58:04.128871Z,"Get Patient Conditions",450
+2025-08-08T17:58:04.132801Z,"Get Active Orders",14
+2025-08-08T17:58:04.138651Z,"Login",1140
+2025-08-08T17:58:04.289796Z,"Create a patient list",1039
+2025-08-08T17:58:04.320439Z,"Get all patient lists",31754
+2025-08-08T17:58:04.608630Z,"Save Vitals",3199
+2025-08-08T17:58:04.756042Z,"Get Locations by Tag and Query",10667
+2025-08-08T17:58:04.814908Z,"Get medication request encounters",8663
+2025-08-08T17:58:04.819715Z,"Get patient age",10
+2025-08-08T17:58:04.822225Z,"Get patient age",10
+2025-08-08T17:58:04.824431Z,"Get patient age",0
+2025-08-08T17:58:04.827412Z,"Get patient age",0
+2025-08-08T17:58:04.829453Z,"Get patient age",0
+2025-08-08T17:58:04.984372Z,"Select Location",1140
+2025-08-08T17:58:04.987052Z,"Get Address Template",1428
+2025-08-08T17:58:04.990690Z,"Get Relationship Types",5960
+2025-08-08T17:58:05.002195Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:05.004249Z,"Get Module Information",1237
+2025-08-08T17:58:05.007757Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:05.010683Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:05.013855Z,"Get Identifier Source",1233
+2025-08-08T17:58:05.017099Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:05.027023Z,"Get Visits",4189
+2025-08-08T17:58:05.031571Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:05.033949Z,"Get Identifier Source",0
+2025-08-08T17:58:05.037500Z,"Get Queue Entry",29
+2025-08-08T17:58:05.171326Z,"Get locations",41279
+2025-08-08T17:58:05.257337Z,"Select Location",1140
+2025-08-08T17:58:05.259902Z,"Get Address Template",1428
+2025-08-08T17:58:05.263884Z,"Get Relationship Types",5960
+2025-08-08T17:58:05.276664Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:05.278777Z,"Get Module Information",1237
+2025-08-08T17:58:05.282291Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:05.285577Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:05.288697Z,"Get Identifier Source",1233
+2025-08-08T17:58:05.292001Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:05.301875Z,"Get Visits",4189
+2025-08-08T17:58:05.306422Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:05.308755Z,"Get Identifier Source",0
+2025-08-08T17:58:05.312358Z,"Get Queue Entry",29
+2025-08-08T17:58:05.329358Z,"Get Active Visits of Patient",587
+2025-08-08T17:58:05.333565Z,"Get Specific Visit Details",573
+2025-08-08T17:58:05.335468Z,"Get the details of a orderType",533
+2025-08-08T17:58:05.343066Z,"Get all Lab order details",28680
+2025-08-08T17:58:05.344133Z,"Get Module Information",0
+2025-08-08T17:58:05.360173Z,"Add a lab order",1722
+2025-08-08T17:58:05.574410Z,"Get Address Template",0
+2025-08-08T17:58:05.583881Z,"Get Patient Identifier Types",0
+2025-08-08T17:58:05.591717Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:05.597524Z,"Get Relationship Types",0
+2025-08-08T17:58:05.600464Z,"Get Module Information",0
+2025-08-08T17:58:05.604699Z,"Get Person Attribute Type",622
+2025-08-08T17:58:05.613496Z,"Get Auto Generation Options",0
+2025-08-08T17:58:05.616043Z,"Get Ordered Address Hierarchy Levels",2
+2025-08-08T17:58:05.620487Z,"Get Identifier Source",0
+2025-08-08T17:58:05.625394Z,"Get the status of patient death",0
+2025-08-08T17:58:05.635054Z,"Get patient identification photo",14
+2025-08-08T17:58:05.644513Z,"Get Patient Summary Data",0
+2025-08-08T17:58:05.651193Z,"Get Person Attributes",14
+2025-08-08T17:58:05.657726Z,"Get Patient Identifiers",202
+2025-08-08T17:58:05.663836Z,"Get Relationships of Person",14
+2025-08-08T17:58:06.443045Z,"Close medication",1418
+2025-08-08T17:58:06.507777Z,"Get medication request encounters",10200
+2025-08-08T17:58:06.524996Z,"Get Medication Request by UUID",0
+2025-08-08T17:58:06.559288Z,"Get Specific Medication Requests",7185
+2025-08-08T17:58:06.575311Z,"Discontinue the drug order",3278
+2025-08-08T17:58:06.595303Z,"End Visit",1484
+2025-08-08T17:58:06.659248Z,"Get Current Visit of Patient",105512
+2025-08-08T17:58:06.692912Z,"Get Visits of Patient",115873
+2025-08-08T17:58:06.700185Z,"Login",1140
+2025-08-08T17:58:07.006854Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:07.016628Z,"Get the status of patient death",49
+2025-08-08T17:58:07.025047Z,"Get Patient Summary Data",1783
+2025-08-08T17:58:07.029757Z,"Get All Appointment Services(full)",0
+2025-08-08T17:58:07.036500Z,"Get patient identification photo",14
+2025-08-08T17:58:07.045480Z,"Get Queue Entry",29
+2025-08-08T17:58:07.054408Z,"Get All Providers",1359
+2025-08-08T17:58:07.061221Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:07.331131Z,"Get patient list details",689
+2025-08-08T17:58:07.334794Z,"Fetch members of patient list",14
+2025-08-08T17:58:07.341151Z,"Login",1140
+2025-08-08T17:58:07.735450Z,"Get locations",41279
+2025-08-08T17:58:07.836916Z,"Get Patient Allergy Intolerance",448
+2025-08-08T17:58:07.881693Z,"Get Specific Medication Requests",3572
+2025-08-08T17:58:07.891397Z,"Get Encounter With Visit and Diagnoses",210
+2025-08-08T17:58:07.894855Z,"Get All Providers",1359
+2025-08-08T17:58:07.908352Z,"Get Patient Conditions",8710
+2025-08-08T17:58:08.049669Z,"Get Admission Location Info",1836
+2025-08-08T17:58:08.069932Z,"Get Admission Info",14
+2025-08-08T17:58:08.078645Z,"Get Inpatient Request",14
+2025-08-08T17:58:08.148954Z,"Get Patients",113383
+2025-08-08T17:58:08.154358Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.159177Z,"Get patient identification photo",14
+2025-08-08T17:58:08.162709Z,"Get the status of patient death",49
+2025-08-08T17:58:08.165765Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.169847Z,"Get patient identification photo",14
+2025-08-08T17:58:08.172758Z,"Get the status of patient death",49
+2025-08-08T17:58:08.175435Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.178622Z,"Get patient identification photo",14
+2025-08-08T17:58:08.181011Z,"Get the status of patient death",49
+2025-08-08T17:58:08.183614Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.186466Z,"Get patient identification photo",14
+2025-08-08T17:58:08.189103Z,"Get the status of patient death",49
+2025-08-08T17:58:08.191664Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.194538Z,"Get patient identification photo",14
+2025-08-08T17:58:08.196764Z,"Get the status of patient death",49
+2025-08-08T17:58:08.199271Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.202135Z,"Get patient identification photo",14
+2025-08-08T17:58:08.204421Z,"Get the status of patient death",49
+2025-08-08T17:58:08.206994Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.209716Z,"Get patient identification photo",14
+2025-08-08T17:58:08.211906Z,"Get the status of patient death",49
+2025-08-08T17:58:08.214380Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.217297Z,"Get patient identification photo",14
+2025-08-08T17:58:08.219431Z,"Get the status of patient death",49
+2025-08-08T17:58:08.221984Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.224944Z,"Get patient identification photo",14
+2025-08-08T17:58:08.227056Z,"Get the status of patient death",49
+2025-08-08T17:58:08.229417Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.232099Z,"Get patient identification photo",14
+2025-08-08T17:58:08.234240Z,"Get the status of patient death",49
+2025-08-08T17:58:08.236639Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.239315Z,"Get patient identification photo",14
+2025-08-08T17:58:08.241436Z,"Get the status of patient death",49
+2025-08-08T17:58:08.244002Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.246815Z,"Get patient identification photo",14
+2025-08-08T17:58:08.248770Z,"Get the status of patient death",49
+2025-08-08T17:58:08.251089Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.254270Z,"Get patient identification photo",14
+2025-08-08T17:58:08.257087Z,"Get the status of patient death",49
+2025-08-08T17:58:08.260374Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.263718Z,"Get patient identification photo",14
+2025-08-08T17:58:08.266167Z,"Get the status of patient death",49
+2025-08-08T17:58:08.269125Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.272200Z,"Get patient identification photo",14
+2025-08-08T17:58:08.274358Z,"Get the status of patient death",49
+2025-08-08T17:58:08.276776Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.279901Z,"Get patient identification photo",14
+2025-08-08T17:58:08.281918Z,"Get the status of patient death",49
+2025-08-08T17:58:08.284264Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.287063Z,"Get patient identification photo",14
+2025-08-08T17:58:08.289025Z,"Get the status of patient death",49
+2025-08-08T17:58:08.291263Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.294161Z,"Get patient identification photo",14
+2025-08-08T17:58:08.296367Z,"Get the status of patient death",49
+2025-08-08T17:58:08.298850Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.301713Z,"Get patient identification photo",14
+2025-08-08T17:58:08.303744Z,"Get the status of patient death",49
+2025-08-08T17:58:08.306070Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.308684Z,"Get patient identification photo",14
+2025-08-08T17:58:08.310570Z,"Get the status of patient death",49
+2025-08-08T17:58:08.312710Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.315793Z,"Get patient identification photo",14
+2025-08-08T17:58:08.318369Z,"Get the status of patient death",49
+2025-08-08T17:58:08.321071Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.324044Z,"Get patient identification photo",14
+2025-08-08T17:58:08.326238Z,"Get the status of patient death",49
+2025-08-08T17:58:08.328892Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.331784Z,"Get patient identification photo",14
+2025-08-08T17:58:08.333907Z,"Get the status of patient death",49
+2025-08-08T17:58:08.336524Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.339585Z,"Get patient identification photo",14
+2025-08-08T17:58:08.342082Z,"Get the status of patient death",49
+2025-08-08T17:58:08.346299Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.351183Z,"Get patient identification photo",14
+2025-08-08T17:58:08.355290Z,"Get the status of patient death",49
+2025-08-08T17:58:08.359377Z,"Get locations",41279
+2025-08-08T17:58:08.360741Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.365228Z,"Get patient identification photo",14
+2025-08-08T17:58:08.368454Z,"Get the status of patient death",49
+2025-08-08T17:58:08.372001Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.375628Z,"Get patient identification photo",14
+2025-08-08T17:58:08.378209Z,"Get the status of patient death",49
+2025-08-08T17:58:08.378495Z,"End Visit",1480
+2025-08-08T17:58:08.381348Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.384372Z,"Get patient identification photo",14
+2025-08-08T17:58:08.386217Z,"Get Patients",113383
+2025-08-08T17:58:08.386835Z,"Get the status of patient death",49
+2025-08-08T17:58:08.390710Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.390747Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.394874Z,"Get patient identification photo",14
+2025-08-08T17:58:08.394944Z,"Get patient identification photo",14
+2025-08-08T17:58:08.397962Z,"Get the status of patient death",49
+2025-08-08T17:58:08.398210Z,"Get the status of patient death",49
+2025-08-08T17:58:08.402095Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.402126Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.406473Z,"Get patient identification photo",14
+2025-08-08T17:58:08.406496Z,"Get patient identification photo",14
+2025-08-08T17:58:08.409781Z,"Get the status of patient death",49
+2025-08-08T17:58:08.409859Z,"Get the status of patient death",49
+2025-08-08T17:58:08.413719Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.413741Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.418067Z,"Get patient identification photo",14
+2025-08-08T17:58:08.418623Z,"Get patient identification photo",14
+2025-08-08T17:58:08.421708Z,"Get the status of patient death",49
+2025-08-08T17:58:08.421739Z,"Get the status of patient death",49
+2025-08-08T17:58:08.425318Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.425370Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.429491Z,"Get patient identification photo",14
+2025-08-08T17:58:08.429619Z,"Get patient identification photo",14
+2025-08-08T17:58:08.429925Z,"Get Current Visit of Patient",114692
+2025-08-08T17:58:08.432882Z,"Get the status of patient death",49
+2025-08-08T17:58:08.432912Z,"Get the status of patient death",49
+2025-08-08T17:58:08.436315Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.436384Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.440579Z,"Get patient identification photo",14
+2025-08-08T17:58:08.440613Z,"Get patient identification photo",14
+2025-08-08T17:58:08.443812Z,"Get the status of patient death",49
+2025-08-08T17:58:08.443838Z,"Get the status of patient death",49
+2025-08-08T17:58:08.447314Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.447355Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.451504Z,"Get patient identification photo",14
+2025-08-08T17:58:08.451524Z,"Get patient identification photo",14
+2025-08-08T17:58:08.454568Z,"Get the status of patient death",49
+2025-08-08T17:58:08.454592Z,"Get the status of patient death",49
+2025-08-08T17:58:08.458293Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.458318Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.463917Z,"Get patient identification photo",14
+2025-08-08T17:58:08.463963Z,"Get patient identification photo",14
+2025-08-08T17:58:08.468322Z,"Get the status of patient death",49
+2025-08-08T17:58:08.468399Z,"Get the status of patient death",49
+2025-08-08T17:58:08.472456Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.472490Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.473498Z,"Get Visits of Patient",56398
+2025-08-08T17:58:08.477728Z,"Get patient identification photo",14
+2025-08-08T17:58:08.477767Z,"Get patient identification photo",14
+2025-08-08T17:58:08.480424Z,"Login",1140
+2025-08-08T17:58:08.481058Z,"Get the status of patient death",49
+2025-08-08T17:58:08.481224Z,"Get the status of patient death",49
+2025-08-08T17:58:08.484412Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.484433Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.488345Z,"Get patient identification photo",14
+2025-08-08T17:58:08.488370Z,"Get patient identification photo",14
+2025-08-08T17:58:08.491358Z,"Get the status of patient death",49
+2025-08-08T17:58:08.491381Z,"Get the status of patient death",49
+2025-08-08T17:58:08.494712Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.494734Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.498515Z,"Get patient identification photo",14
+2025-08-08T17:58:08.498701Z,"Get patient identification photo",14
+2025-08-08T17:58:08.501543Z,"Get the status of patient death",49
+2025-08-08T17:58:08.501558Z,"Get the status of patient death",49
+2025-08-08T17:58:08.504839Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.508364Z,"Get patient identification photo",14
+2025-08-08T17:58:08.511141Z,"Get the status of patient death",49
+2025-08-08T17:58:08.515098Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.518590Z,"Get patient identification photo",14
+2025-08-08T17:58:08.521028Z,"Get the status of patient death",49
+2025-08-08T17:58:08.523800Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.527198Z,"Get patient identification photo",14
+2025-08-08T17:58:08.529593Z,"Get the status of patient death",49
+2025-08-08T17:58:08.532260Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.535121Z,"Get patient identification photo",14
+2025-08-08T17:58:08.537570Z,"Get the status of patient death",49
+2025-08-08T17:58:08.540284Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.543216Z,"Get patient identification photo",14
+2025-08-08T17:58:08.545267Z,"Get the status of patient death",49
+2025-08-08T17:58:08.547582Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.550432Z,"Get patient identification photo",14
+2025-08-08T17:58:08.552438Z,"Get the status of patient death",49
+2025-08-08T17:58:08.554677Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.557293Z,"Get patient identification photo",14
+2025-08-08T17:58:08.559356Z,"Get the status of patient death",49
+2025-08-08T17:58:08.561588Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.564077Z,"Get patient identification photo",14
+2025-08-08T17:58:08.565925Z,"Get the status of patient death",49
+2025-08-08T17:58:08.568137Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.570596Z,"Get patient identification photo",14
+2025-08-08T17:58:08.572665Z,"Get the status of patient death",49
+2025-08-08T17:58:08.575116Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.577821Z,"Get patient identification photo",14
+2025-08-08T17:58:08.579698Z,"Get the status of patient death",49
+2025-08-08T17:58:08.581907Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.584607Z,"Get patient identification photo",14
+2025-08-08T17:58:08.586538Z,"Get the status of patient death",49
+2025-08-08T17:58:08.588707Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.591220Z,"Get patient identification photo",14
+2025-08-08T17:58:08.593136Z,"Get the status of patient death",49
+2025-08-08T17:58:08.595869Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.598766Z,"Get patient identification photo",14
+2025-08-08T17:58:08.600757Z,"Get the status of patient death",49
+2025-08-08T17:58:08.602965Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.605457Z,"Get patient identification photo",14
+2025-08-08T17:58:08.607420Z,"Get the status of patient death",49
+2025-08-08T17:58:08.609589Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.612098Z,"Get patient identification photo",14
+2025-08-08T17:58:08.613962Z,"Get the status of patient death",49
+2025-08-08T17:58:08.616088Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.618663Z,"Get patient identification photo",14
+2025-08-08T17:58:08.620583Z,"Get the status of patient death",49
+2025-08-08T17:58:08.622764Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.625246Z,"Get patient identification photo",14
+2025-08-08T17:58:08.627058Z,"Get the status of patient death",49
+2025-08-08T17:58:08.629374Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.632397Z,"Get patient identification photo",14
+2025-08-08T17:58:08.633873Z,"Get Drug Orders except the cancelled and expired",14
+2025-08-08T17:58:08.634547Z,"Get the status of patient death",49
+2025-08-08T17:58:08.637057Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.637801Z,"Get Drug Orders except the discontinued orders",14
+2025-08-08T17:58:08.640214Z,"Get patient identification photo",14
+2025-08-08T17:58:08.642807Z,"Get the status of patient death",49
+2025-08-08T17:58:08.642874Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:08.645451Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.648294Z,"Get patient identification photo",14
+2025-08-08T17:58:08.650309Z,"Get the status of patient death",49
+2025-08-08T17:58:08.652706Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.655202Z,"Get patient identification photo",14
+2025-08-08T17:58:08.657134Z,"Get the status of patient death",49
+2025-08-08T17:58:08.659553Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.662728Z,"Get patient identification photo",14
+2025-08-08T17:58:08.665148Z,"Get the status of patient death",49
+2025-08-08T17:58:08.667637Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.670358Z,"Get patient identification photo",14
+2025-08-08T17:58:08.672418Z,"Get the status of patient death",49
+2025-08-08T17:58:08.674929Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.677637Z,"Get patient identification photo",14
+2025-08-08T17:58:08.679713Z,"Get the status of patient death",49
+2025-08-08T17:58:08.682251Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.685112Z,"Get patient identification photo",14
+2025-08-08T17:58:08.687176Z,"Get the status of patient death",49
+2025-08-08T17:58:08.689488Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.692114Z,"Get patient identification photo",14
+2025-08-08T17:58:08.694136Z,"Get the status of patient death",49
+2025-08-08T17:58:08.696798Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.699668Z,"Get patient identification photo",14
+2025-08-08T17:58:08.701760Z,"Get the status of patient death",49
+2025-08-08T17:58:08.704205Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:08.706978Z,"Get patient identification photo",14
+2025-08-08T17:58:08.708931Z,"Get the status of patient death",49
+2025-08-08T17:58:09.510851Z,"Get locations",41279
+2025-08-08T17:58:09.639151Z,"Get Allergies of Patient",17225
+2025-08-08T17:58:09.677656Z,"Get Drug Allergens",118868
+2025-08-08T17:58:09.698220Z,"Get Environment Allergens",93956
+2025-08-08T17:58:09.706267Z,"Get Food Allergens",28759
+2025-08-08T17:58:09.716525Z,"Get Allergic Reactions Allergens",45987
+2025-08-08T17:58:10.183228Z,"Select Location",1140
+2025-08-08T17:58:10.187946Z,"Get Address Template",1428
+2025-08-08T17:58:10.194340Z,"Get Relationship Types",5960
+2025-08-08T17:58:10.211713Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:10.215087Z,"Get Module Information",1237
+2025-08-08T17:58:10.220151Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:10.224720Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:10.229256Z,"Get Identifier Source",1233
+2025-08-08T17:58:10.233434Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:10.243537Z,"Get Visits",2805
+2025-08-08T17:58:10.248402Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:10.251266Z,"Get Identifier Source",0
+2025-08-08T17:58:10.255356Z,"Get Queue Entry",29
+2025-08-08T17:58:10.373852Z,"Get all active Lab orders",1341
+2025-08-08T17:58:10.377961Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:10.435192Z,"Get Lab Orders by full filler status",30159
+2025-08-08T17:58:10.438250Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:10.733557Z,"Edit patient details",1829
+2025-08-08T17:58:10.740876Z,"Login",1140
+2025-08-08T17:58:10.917988Z,"Get Patient Summary Data",1783
+2025-08-08T17:58:10.936009Z,"Get Order Entry Config",26242
+2025-08-08T17:58:10.946750Z,"Get ValueSet by UUID",1660
+2025-08-08T17:58:10.954950Z,"Get ValueSet by UUID",1285
+2025-08-08T17:58:10.972326Z,"Get Medication Request by UUID",1744
+2025-08-08T17:58:10.974473Z,"Get Medication by UUID",879
+2025-08-08T17:58:10.977787Z,"Get All Providers",0
+2025-08-08T17:58:10.980932Z,"Search Medication by Code",4395
+2025-08-08T17:58:11.007341Z,"Get Specific Medication Requests",3572
+2025-08-08T17:58:11.023079Z,"Get patient identification photo",14
+2025-08-08T17:58:11.029645Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:11.041462Z,"Get Active Visits of Patient",1211
+2025-08-08T17:58:11.048956Z,"Get Visit Queue Entry",0
+2025-08-08T17:58:11.053405Z,"Get the status of patient death",49
+2025-08-08T17:58:11.512515Z,"Get Visit Types",1097
+2025-08-08T17:58:11.522065Z,"Get Locations That Support Visits",2180
+2025-08-08T17:58:11.535712Z,"Get Program Enrollments of Patient",4684
+2025-08-08T17:58:11.542521Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:58:11.545257Z,"Get Appointments of a Patient",2
+2025-08-08T17:58:11.556808Z,"Submit Visit Form",1231
+2025-08-08T17:58:11.560242Z,"Get Beds for Patient",14
+2025-08-08T17:58:11.571040Z,"Save Ward Encounter",1773
+2025-08-08T17:58:11.717952Z,"Get Visit Types",1097
+2025-08-08T17:58:11.731067Z,"Get Locations That Support Visits",2180
+2025-08-08T17:58:11.739161Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:58:11.747473Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:58:11.755202Z,"Get Appointments of a Patient",1152
+2025-08-08T17:58:11.765595Z,"Submit Visit Form",1241
+2025-08-08T17:58:11.768108Z,"Get locations",41279
+2025-08-08T17:58:11.770133Z,"Get patient identification photo",14
+2025-08-08T17:58:11.772873Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:11.777134Z,"Get Patient Summary Data",1191
+2025-08-08T17:58:11.782361Z,"Get Active Visits of Patient",587
+2025-08-08T17:58:11.787298Z,"Get Queue Entry",29
+2025-08-08T17:58:11.789607Z,"Get the status of patient death",49
+2025-08-08T17:58:11.790526Z,"Get queue entry number",97
+2025-08-08T17:58:11.807542Z,"Submit visit queue entry",7831
+2025-08-08T17:58:11.817049Z,"Get Queue Entry",8963
+2025-08-08T17:58:12.083184Z,"Check Appointment Conflicts",0
+2025-08-08T17:58:12.107259Z,"Create Appointment",1212
+2025-08-08T17:58:12.747367Z,"Select Location",1140
+2025-08-08T17:58:12.752950Z,"Get Address Template",1428
+2025-08-08T17:58:12.760420Z,"Get Relationship Types",5960
+2025-08-08T17:58:12.777138Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:12.779910Z,"Get Module Information",1237
+2025-08-08T17:58:12.784202Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:12.787795Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:12.791856Z,"Get Identifier Source",1233
+2025-08-08T17:58:12.795844Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:12.805961Z,"Get Visits",3501
+2025-08-08T17:58:12.810765Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:12.813594Z,"Get Identifier Source",0
+2025-08-08T17:58:12.825555Z,"Get Queue Entry",8963
+2025-08-08T17:58:13.260921Z,"Get Address Template",0
+2025-08-08T17:58:13.269041Z,"Get Patient Identifier Types",0
+2025-08-08T17:58:13.274195Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:13.278268Z,"Get Relationship Types",0
+2025-08-08T17:58:13.280239Z,"Get Module Information",0
+2025-08-08T17:58:13.282945Z,"Get Person Attribute Type",622
+2025-08-08T17:58:13.286942Z,"Get Immunizations of Patient",2940
+2025-08-08T17:58:13.289375Z,"Get Auto Generation Options",0
+2025-08-08T17:58:13.290560Z,"Get Ordered Address Hierarchy Levels",2
+2025-08-08T17:58:13.293548Z,"Get Identifier Source",0
+2025-08-08T17:58:13.293629Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:13.298776Z,"Get Specific Visit Details",0
+2025-08-08T17:58:13.365540Z,"Select Location",1140
+2025-08-08T17:58:13.367289Z,"Get Address Template",1428
+2025-08-08T17:58:13.369918Z,"Get Relationship Types",5960
+2025-08-08T17:58:13.378222Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:13.379573Z,"Get Module Information",1237
+2025-08-08T17:58:13.382168Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:13.384366Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:13.386763Z,"Get Identifier Source",1233
+2025-08-08T17:58:13.389590Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:13.397795Z,"Get Visits",3501
+2025-08-08T17:58:13.401898Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:13.404088Z,"Get Identifier Source",0
+2025-08-08T17:58:13.413689Z,"Get Queue Entry",8963
+2025-08-08T17:58:13.689893Z,"Get Observation Tree Details",5416
+2025-08-08T17:58:13.735842Z,"Get Observation Tree Details",11197
+2025-08-08T17:58:13.739326Z,"Get Observation Tree Details",190
+2025-08-08T17:58:13.755945Z,"Get Lab Results of Patient",44539
+2025-08-08T17:58:13.764035Z,"Get Concept",0
+2025-08-08T17:58:13.768588Z,"Get Concept",0
+2025-08-08T17:58:13.772873Z,"Get Concept",0
+2025-08-08T17:58:13.777484Z,"Get Concept",0
+2025-08-08T17:58:13.781450Z,"Get Concept",0
+2025-08-08T17:58:13.786950Z,"Get Concept",0
+2025-08-08T17:58:13.792326Z,"Get Concept",0
+2025-08-08T17:58:13.796775Z,"Get Concept",0
+2025-08-08T17:58:13.801439Z,"Get Concept",0
+2025-08-08T17:58:13.805621Z,"Get Concept",0
+2025-08-08T17:58:13.810119Z,"Get Concept",0
+2025-08-08T17:58:13.813826Z,"Get Concept",0
+2025-08-08T17:58:13.818086Z,"Get Concept",0
+2025-08-08T17:58:13.821923Z,"Get Concept",0
+2025-08-08T17:58:13.825971Z,"Get Concept",0
+2025-08-08T17:58:13.830118Z,"Get Concept",0
+2025-08-08T17:58:13.834296Z,"Get Concept",0
+2025-08-08T17:58:13.838717Z,"Get Concept",0
+2025-08-08T17:58:13.842593Z,"Get Concept",0
+2025-08-08T17:58:13.846723Z,"Get Concept",0
+2025-08-08T17:58:13.851972Z,"Get Concept",0
+2025-08-08T17:58:13.855795Z,"Get Concept",0
+2025-08-08T17:58:13.861068Z,"Get Concept",0
+2025-08-08T17:58:13.864882Z,"Get Concept",0
+2025-08-08T17:58:13.869530Z,"Get Concept",0
+2025-08-08T17:58:13.872908Z,"Get Concept",0
+2025-08-08T17:58:14.521096Z,"Select Location",1140
+2025-08-08T17:58:14.525430Z,"Get Address Template",1428
+2025-08-08T17:58:14.532096Z,"Get Relationship Types",5960
+2025-08-08T17:58:14.548620Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:14.551371Z,"Get Module Information",1237
+2025-08-08T17:58:14.555536Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:14.558825Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:14.562489Z,"Get Identifier Source",1233
+2025-08-08T17:58:14.566156Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:14.576147Z,"Get Visits",3501
+2025-08-08T17:58:14.581032Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:14.583471Z,"Get Identifier Source",0
+2025-08-08T17:58:14.594054Z,"Get Queue Entry",8963
+2025-08-08T17:58:14.736705Z,"Save an Allergy",1533
+2025-08-08T17:58:14.742409Z,"Login",1140
+2025-08-08T17:58:14.821663Z,"Get service concept set",48
+2025-08-08T17:58:14.829184Z,"Get Concept",7419
+2025-08-08T17:58:14.840366Z,"Submit new Service queue",2208
+2025-08-08T17:58:15.461459Z,"Update full filler status",0
+2025-08-08T17:58:15.476214Z,"Get all active Lab orders",1348
+2025-08-08T17:58:15.487435Z,"Get Lab Orders by full filler status",1348
+2025-08-08T17:58:15.543631Z,"Get Lab Orders by full filler status",30159
+2025-08-08T17:58:15.546544Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:15.775414Z,"Get locations",41279
+2025-08-08T17:58:15.833410Z,"Get Visit Types",1097
+2025-08-08T17:58:15.880847Z,"Get Current Visit of Patient",105437
+2025-08-08T17:58:15.914934Z,"Get Visits of Patient",115798
+2025-08-08T17:58:15.917783Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:58:15.921720Z,"Get Visit Queue Entry",14
+2025-08-08T17:58:15.923299Z,"Get Appointments of a Patient",2
+2025-08-08T17:58:16.096696Z,"Dispense medication form submission",1954
+2025-08-08T17:58:16.134737Z,"Get medication request encounters",5632
+2025-08-08T17:58:16.151495Z,"Get Medication Request by UUID",0
+2025-08-08T17:58:16.185118Z,"Get Specific Medication Requests",5645
+2025-08-08T17:58:16.458188Z,"Get all patient lists",31754
+2025-08-08T17:58:16.463121Z,"Get all patient lists",29
+2025-08-08T17:58:16.489819Z,"Get all patient lists",31802
+2025-08-08T17:58:16.583286Z,"Get Active Visits of Patient",1378
+2025-08-08T17:58:16.586761Z,"Get isVisitsEnabled",16
+2025-08-08T17:58:16.590599Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:58:16.640567Z,"Get Patient Observations",173165
+2025-08-08T17:58:16.665935Z,"Get Vitals concept reference ranges",2828
+2025-08-08T17:58:16.671330Z,"Get Specific Visit Details",1364
+2025-08-08T17:58:16.709630Z,"Get Transfer Locations configuration data",10181
+2025-08-08T17:58:16.725004Z,"Get Transferable locations",4651
+2025-08-08T17:58:16.746447Z,"Save Ward Encounter",2056
+2025-08-08T17:58:16.771907Z,"Select Location",1140
+2025-08-08T17:58:16.773138Z,"Get Address Template",1428
+2025-08-08T17:58:16.775155Z,"Get Relationship Types",5960
+2025-08-08T17:58:16.782022Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:16.783370Z,"Get Module Information",1237
+2025-08-08T17:58:16.785696Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:16.787977Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:16.790278Z,"Get Identifier Source",1233
+2025-08-08T17:58:16.792789Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:16.799864Z,"Get Visits",3501
+2025-08-08T17:58:16.803883Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:16.806363Z,"Get Identifier Source",0
+2025-08-08T17:58:16.816049Z,"Get Queue Entry",8963
+2025-08-08T17:58:16.820365Z,"Get Patient Summary Data",3883
+2025-08-08T17:58:16.827327Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:16.829454Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:16.830942Z,"Get isVisitsEnabled",16
+2025-08-08T17:58:16.836604Z,"Get the status of patient death",49
+2025-08-08T17:58:16.838772Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:58:16.882161Z,"Get Patient Observations",160898
+2025-08-08T17:58:16.917673Z,"Get Patient Observations",129557
+2025-08-08T17:58:16.934277Z,"Get Patient Observations",31829
+2025-08-08T17:58:16.942153Z,"Get Visit Queue Entry",14
+2025-08-08T17:58:16.968949Z,"Get Patient Conditions",24399
+2025-08-08T17:58:16.979920Z,"Get Active Orders",14
+2025-08-08T17:58:17.111917Z,"Get Visit Types",1097
+2025-08-08T17:58:17.117303Z,"Get Locations That Support Visits",2180
+2025-08-08T17:58:17.123531Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:58:17.129071Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:58:17.131444Z,"Get Appointments of a Patient",2
+2025-08-08T17:58:17.141493Z,"Get Visits",3501
+2025-08-08T17:58:17.150511Z,"Submit Visit Form",1237
+2025-08-08T17:58:17.157579Z,"Submit Appointment StatusChange",1212
+2025-08-08T17:58:17.893082Z,"Submit transition request",1685
+2025-08-08T17:58:17.910681Z,"Get Queue Entry",19017
+2025-08-08T17:58:17.931964Z,"End Visit",1267
+2025-08-08T17:58:17.941572Z,"Get Current Visit of Patient",11387
+2025-08-08T17:58:17.954212Z,"Get Visits of Patient",21748
+2025-08-08T17:58:17.958997Z,"Login",1140
+2025-08-08T17:58:18.318813Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:18.328426Z,"Get Specific Visit Details",0
+2025-08-08T17:58:18.347505Z,"Get Immunizations of Patient",2940
+2025-08-08T17:58:18.354488Z,"Get all immunizations",2244
+2025-08-08T17:58:18.992865Z,"Get locations",41279
+2025-08-08T17:58:19.206887Z,"Get Patient Summary Data",0
+2025-08-08T17:58:19.229291Z,"Get ValueSet by UUID",2315
+2025-08-08T17:58:19.236867Z,"Get patient identification photo",0
+2025-08-08T17:58:19.240455Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:19.248738Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:19.252725Z,"Get the status of patient death",0
+2025-08-08T17:58:19.507936Z,"Create a patient list",1039
+2025-08-08T17:58:19.538799Z,"Get all patient lists",31754
+2025-08-08T17:58:19.600549Z,"Get Patient Summary Data",1181
+2025-08-08T17:58:19.604718Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:19.607474Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:19.609517Z,"Get isVisitsEnabled",16
+2025-08-08T17:58:19.612248Z,"Get the status of patient death",49
+2025-08-08T17:58:19.614986Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:58:19.646442Z,"Get Patient Observations",107791
+2025-08-08T17:58:19.670967Z,"Get Patient Observations",86890
+2025-08-08T17:58:19.681451Z,"Get Patient Observations",21389
+2025-08-08T17:58:19.685698Z,"Get Visit Queue Entry",14
+2025-08-08T17:58:19.707454Z,"Get Patient Conditions",23774
+2025-08-08T17:58:19.711393Z,"Get Active Orders",14
+2025-08-08T17:58:20.565980Z,"Get specific encounter details",800
+2025-08-08T17:58:20.572649Z,"Get Alkaline concept details",1387
+2025-08-08T17:58:20.601040Z,"Update the specific encounter",1937
+2025-08-08T17:58:20.614940Z,"Update the Lab Order Completion",2780
+2025-08-08T17:58:20.621795Z,"Update full filler status",0
+2025-08-08T17:58:20.624599Z,"Get all active Lab orders",14
+2025-08-08T17:58:20.627064Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:20.676547Z,"Get Lab Orders by full filler status",31538
+2025-08-08T17:58:20.679404Z,"Get Lab Orders by full filler status",0
+2025-08-08T17:58:20.778788Z,"Select Location",1140
+2025-08-08T17:58:20.780396Z,"Get Address Template",1428
+2025-08-08T17:58:20.783039Z,"Get Relationship Types",5960
+2025-08-08T17:58:20.791929Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:20.793229Z,"Get Module Information",1237
+2025-08-08T17:58:20.795893Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:20.801124Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:20.804391Z,"Get Identifier Source",1233
+2025-08-08T17:58:20.807575Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:20.817567Z,"Get Visits",3498
+2025-08-08T17:58:20.822174Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:20.824735Z,"Get Identifier Source",0
+2025-08-08T17:58:20.828189Z,"Get Queue Entry",29
+2025-08-08T17:58:20.832430Z,"Get Patient Summary Data",1187
+2025-08-08T17:58:20.835693Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:20.838163Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:20.839747Z,"Get isVisitsEnabled",16
+2025-08-08T17:58:20.842044Z,"Get the status of patient death",49
+2025-08-08T17:58:20.844464Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:58:20.892966Z,"Get Patient Observations",165651
+2025-08-08T17:58:20.935086Z,"Submit Visit Form",1235
+2025-08-08T17:58:20.942609Z,"Get Patient Observations",182161
+2025-08-08T17:58:20.964979Z,"Get Patient Observations",55907
+2025-08-08T17:58:20.969792Z,"Get Visit Queue Entry",14
+2025-08-08T17:58:20.971349Z,"Get Current Visit of Patient",86584
+2025-08-08T17:58:20.995528Z,"Get Patient Conditions",26700
+2025-08-08T17:58:21.000089Z,"Get Active Orders",14
+2025-08-08T17:58:21.005066Z,"Get Visits of Patient",96945
+2025-08-08T17:58:21.771859Z,"Get Active Visits of Patient",2197
+2025-08-08T17:58:21.776321Z,"Get isVisitsEnabled",0
+2025-08-08T17:58:21.781755Z,"Get all the constraints on the vital concepts",0
+2025-08-08T17:58:21.836974Z,"Get Patient Observations",173165
+2025-08-08T17:58:21.855681Z,"Get Vitals concept reference ranges",0
+2025-08-08T17:58:21.861398Z,"Get Specific Visit Details",2183
+2025-08-08T17:58:21.983324Z,"Get Address Template",0
+2025-08-08T17:58:21.987742Z,"Get Patient Identifier Types",0
+2025-08-08T17:58:21.991731Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:21.994564Z,"Get Relationship Types",0
+2025-08-08T17:58:21.996075Z,"Get Module Information",0
+2025-08-08T17:58:21.998511Z,"Get Person Attribute Type",622
+2025-08-08T17:58:22.004109Z,"Get Auto Generation Options",0
+2025-08-08T17:58:22.005227Z,"Get Ordered Address Hierarchy Levels",2
+2025-08-08T17:58:22.008175Z,"Get Identifier Source",0
+2025-08-08T17:58:22.015636Z,"Get the status of patient death",0
+2025-08-08T17:58:22.023602Z,"Get patient identification photo",14
+2025-08-08T17:58:22.031379Z,"Get Patient Summary Data",0
+2025-08-08T17:58:22.037604Z,"Get Person Attributes",14
+2025-08-08T17:58:22.044121Z,"Get Patient Identifiers",202
+2025-08-08T17:58:22.050706Z,"Get Relationships of Person",14
+2025-08-08T17:58:22.289170Z,"Close medication",1417
+2025-08-08T17:58:22.339001Z,"Get medication request encounters",7168
+2025-08-08T17:58:22.356752Z,"Get Medication Request by UUID",0
+2025-08-08T17:58:22.390524Z,"Get Specific Medication Requests",7181
+2025-08-08T17:58:22.410706Z,"Discontinue the drug order",3277
+2025-08-08T17:58:22.429404Z,"End Visit",1483
+2025-08-08T17:58:22.459345Z,"Get Current Visit of Patient",105487
+2025-08-08T17:58:22.495605Z,"Get Visits of Patient",115848
+2025-08-08T17:58:22.544389Z,"Get patient list details",689
+2025-08-08T17:58:22.546963Z,"Fetch members of patient list",14
+2025-08-08T17:58:23.324294Z,"Generate OMRS Identifier",24
+2025-08-08T17:58:23.365017Z,"Send Patient Registration Request",1870
+2025-08-08T17:58:23.381803Z,"Submit Patient immunization",1131
+2025-08-08T17:58:23.383391Z,"Get Immunizations of Patient",442
+2025-08-08T17:58:23.912879Z,"Get Patient Conditions",23993
+2025-08-08T17:58:24.001231Z,"Select Location",1140
+2025-08-08T17:58:24.005166Z,"Get Address Template",1428
+2025-08-08T17:58:24.011081Z,"Get Relationship Types",5960
+2025-08-08T17:58:24.011129Z,"Get Order Types",443
+2025-08-08T17:58:24.019155Z,"Get Active Orders",14
+2025-08-08T17:58:24.025721Z,"Get Appointments for Specific Date",2299
+2025-08-08T17:58:24.027602Z,"Get Module Information",1237
+2025-08-08T17:58:24.031162Z,"Get Patient Identifier Types",971
+2025-08-08T17:58:24.034044Z,"Get Primary Identifier Term Mapping",1222
+2025-08-08T17:58:24.037315Z,"Get Identifier Source",1233
+2025-08-08T17:58:24.040737Z,"Get Locations by Tag and Query",233
+2025-08-08T17:58:24.049517Z,"Get Visits",3496
+2025-08-08T17:58:24.054161Z,"Get Auto Generation Options",2298
+2025-08-08T17:58:24.056718Z,"Get Identifier Source",0
+2025-08-08T17:58:24.060431Z,"Get Queue Entry",29
+2025-08-08T17:58:24.715530Z,"Get Visit Types",1097
+2025-08-08T17:58:24.763270Z,"Get Current Visit of Patient",114732
+2025-08-08T17:58:24.789847Z,"Get Visits of Patient",56423
+2025-08-08T17:58:24.792363Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:58:24.796459Z,"Get Visit Queue Entry",0
+2025-08-08T17:58:24.798046Z,"Get Appointments of a Patient",2
+2025-08-08T17:58:24.895035Z,"Get Transfer Locations configuration data",0
+2025-08-08T17:58:24.910369Z,"Get Transferable locations",4651
+2025-08-08T17:58:24.932539Z,"Save Ward Encounter",2056
+2025-08-08T17:58:25.382259Z,"Get Patient Summary Data",1208
+2025-08-08T17:58:25.391966Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:25.397230Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:25.401088Z,"Get isVisitsEnabled",16
+2025-08-08T17:58:25.405886Z,"Get the status of patient death",49
+2025-08-08T17:58:25.411205Z,"Get all the constraints on the vital concepts",2061
+2025-08-08T17:58:25.414039Z,"Get Patient Observations",867
+2025-08-08T17:58:25.416046Z,"Get Patient Observations",750
+2025-08-08T17:58:25.417549Z,"Get Patient Observations",594
+2025-08-08T17:58:25.424599Z,"Get Visit Queue Entry",14
+2025-08-08T17:58:25.425913Z,"Get Patient Conditions",450
+2025-08-08T17:58:25.430723Z,"Get Active Orders",14
+2025-08-08T17:58:25.728263Z,"End Visit",1487
+2025-08-08T17:58:25.771218Z,"Get Current Visit of Patient",114972
+2025-08-08T17:58:25.799027Z,"Get Visits of Patient",56573
+2025-08-08T17:58:26.101812Z,"Get Patient Observations",182161
+2025-08-08T17:58:26.131400Z,"Get Patient Observations",55907
+2025-08-08T17:58:27.114592Z,"Edit patient details",1829
+2025-08-08T17:58:27.165184Z,"Get Patients",116366
+2025-08-08T17:58:27.170188Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.174175Z,"Get patient identification photo",14
+2025-08-08T17:58:27.176660Z,"Get the status of patient death",49
+2025-08-08T17:58:27.178350Z,"End Visit",1263
+2025-08-08T17:58:27.179470Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.179777Z,"Get Visit Types",0
+2025-08-08T17:58:27.182642Z,"Get patient identification photo",14
+2025-08-08T17:58:27.183024Z,"Get Locations That Support Visits",0
+2025-08-08T17:58:27.185486Z,"Get the status of patient death",49
+2025-08-08T17:58:27.188225Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.190798Z,"Submit Appointment StatusChange",1212
+2025-08-08T17:58:27.190984Z,"Get patient identification photo",14
+2025-08-08T17:58:27.192417Z,"Get All Appointment Services(full)",0
+2025-08-08T17:58:27.192880Z,"Get the status of patient death",49
+2025-08-08T17:58:27.194461Z,"Get all appointments for a specific day",2
+2025-08-08T17:58:27.195040Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.197779Z,"Get patient identification photo",14
+2025-08-08T17:58:27.199969Z,"Get the status of patient death",49
+2025-08-08T17:58:27.202400Z,"Get all appointment summaries",1719
+2025-08-08T17:58:27.202627Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.205693Z,"Get patient identification photo",14
+2025-08-08T17:58:27.208039Z,"Get the status of patient death",49
+2025-08-08T17:58:27.210910Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.213116Z,"Get Appointment By Status",4589
+2025-08-08T17:58:27.214012Z,"Get patient identification photo",14
+2025-08-08T17:58:27.215533Z,"Get Appointment By Status",2
+2025-08-08T17:58:27.216298Z,"Get the status of patient death",49
+2025-08-08T17:58:27.217768Z,"Get Appointment By Status",2
+2025-08-08T17:58:27.218980Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.219862Z,"Get Appointment By Status",2
+2025-08-08T17:58:27.221691Z,"Get all default appointment services",0
+2025-08-08T17:58:27.222124Z,"Get patient identification photo",14
+2025-08-08T17:58:27.224342Z,"Get the status of patient death",49
+2025-08-08T17:58:27.227175Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.230297Z,"Get patient identification photo",14
+2025-08-08T17:58:27.232650Z,"Get the status of patient death",49
+2025-08-08T17:58:27.235332Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.236909Z,"Get all visits of the given location with date",8586
+2025-08-08T17:58:27.238239Z,"Get patient identification photo",14
+2025-08-08T17:58:27.240307Z,"Get the status of patient death",49
+2025-08-08T17:58:27.242711Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.245517Z,"Get patient identification photo",14
+2025-08-08T17:58:27.247569Z,"Get the status of patient death",49
+2025-08-08T17:58:27.250006Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.252701Z,"Get patient identification photo",14
+2025-08-08T17:58:27.254772Z,"Get the status of patient death",49
+2025-08-08T17:58:27.257169Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.259802Z,"Get patient identification photo",14
+2025-08-08T17:58:27.261856Z,"Get the status of patient death",49
+2025-08-08T17:58:27.264288Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.267012Z,"Get patient identification photo",14
+2025-08-08T17:58:27.268959Z,"Get the status of patient death",49
+2025-08-08T17:58:27.271268Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.273967Z,"Get patient identification photo",14
+2025-08-08T17:58:27.276149Z,"Get the status of patient death",49
+2025-08-08T17:58:27.278520Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.281211Z,"Get patient identification photo",14
+2025-08-08T17:58:27.283342Z,"Get the status of patient death",49
+2025-08-08T17:58:27.285884Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.288596Z,"Get patient identification photo",14
+2025-08-08T17:58:27.290593Z,"Get the status of patient death",49
+2025-08-08T17:58:27.292916Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.295393Z,"Get patient identification photo",14
+2025-08-08T17:58:27.297228Z,"Get the status of patient death",49
+2025-08-08T17:58:27.299465Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.302083Z,"Get patient identification photo",14
+2025-08-08T17:58:27.303964Z,"Get the status of patient death",49
+2025-08-08T17:58:27.306209Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.308730Z,"Get patient identification photo",14
+2025-08-08T17:58:27.310559Z,"Get the status of patient death",49
+2025-08-08T17:58:27.312686Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.315191Z,"Get patient identification photo",14
+2025-08-08T17:58:27.317053Z,"Get the status of patient death",49
+2025-08-08T17:58:27.319283Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.321725Z,"Get patient identification photo",14
+2025-08-08T17:58:27.323553Z,"Get the status of patient death",49
+2025-08-08T17:58:27.325714Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.328696Z,"Get patient identification photo",14
+2025-08-08T17:58:27.331029Z,"Get the status of patient death",49
+2025-08-08T17:58:27.333434Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.336101Z,"Get patient identification photo",14
+2025-08-08T17:58:27.338118Z,"Get the status of patient death",49
+2025-08-08T17:58:27.340304Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.342971Z,"Get patient identification photo",14
+2025-08-08T17:58:27.344989Z,"Get the status of patient death",49
+2025-08-08T17:58:27.347268Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.349818Z,"Get patient identification photo",14
+2025-08-08T17:58:27.351671Z,"Get the status of patient death",49
+2025-08-08T17:58:27.353907Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.356391Z,"Get patient identification photo",14
+2025-08-08T17:58:27.358221Z,"Get the status of patient death",49
+2025-08-08T17:58:27.360386Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.362764Z,"Get patient identification photo",14
+2025-08-08T17:58:27.364640Z,"Get the status of patient death",49
+2025-08-08T17:58:27.366719Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.369172Z,"Get patient identification photo",14
+2025-08-08T17:58:27.370990Z,"Get the status of patient death",49
+2025-08-08T17:58:27.373078Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.375490Z,"Get patient identification photo",14
+2025-08-08T17:58:27.377249Z,"Get the status of patient death",49
+2025-08-08T17:58:27.379334Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.381783Z,"Get patient identification photo",14
+2025-08-08T17:58:27.383594Z,"Get the status of patient death",49
+2025-08-08T17:58:27.385772Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.388180Z,"Get patient identification photo",14
+2025-08-08T17:58:27.390019Z,"Get the status of patient death",49
+2025-08-08T17:58:27.392105Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.394535Z,"Get patient identification photo",14
+2025-08-08T17:58:27.396536Z,"Get the status of patient death",49
+2025-08-08T17:58:27.398886Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.405628Z,"Get patient identification photo",14
+2025-08-08T17:58:27.409087Z,"Get the status of patient death",49
+2025-08-08T17:58:27.412773Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.416395Z,"Get patient identification photo",14
+2025-08-08T17:58:27.419507Z,"Get the status of patient death",49
+2025-08-08T17:58:27.422771Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.426204Z,"Get patient identification photo",14
+2025-08-08T17:58:27.428905Z,"Get the status of patient death",49
+2025-08-08T17:58:27.431771Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.434810Z,"Get patient identification photo",14
+2025-08-08T17:58:27.437564Z,"Get the status of patient death",49
+2025-08-08T17:58:27.440772Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.444338Z,"Get patient identification photo",14
+2025-08-08T17:58:27.446904Z,"Get the status of patient death",49
+2025-08-08T17:58:27.449722Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.452831Z,"Get patient identification photo",14
+2025-08-08T17:58:27.455308Z,"Get the status of patient death",49
+2025-08-08T17:58:27.458023Z,"Get Active Visits of Patient",14
+2025-08-08T17:58:27.467208Z,"Get patient identification photo",14
+2025-08-08T17:58:27.470012Z,"Get the status of patient death",49
+2025-08-08T17:58:27.968279Z,"Get locations",41279
+2025-08-08T17:58:27.974396Z,"Get Locations Search Set",1057
+2025-08-08T17:58:27.978438Z,"Change the session location",1344
+2025-08-08T17:58:27.983198Z,"Get Admission Location Info",1812
+2025-08-08T17:58:27.998336Z,"Get Admission Info",14
+2025-08-08T17:58:28.019882Z,"Get Inpatient Request",41485
+2025-08-08T17:58:28.408365Z,"Get Attachments of Patient",743
+2025-08-08T17:58:28.412585Z,"Get Allowed File Extensions",42
+2025-08-08T17:58:28.952491Z,"Get Patient Conditions",23993
+2025-08-08T17:58:29.032518Z,"Get Active Visits of Patient",581
+2025-08-08T17:58:29.035292Z,"Search for Drug",14
+2025-08-08T17:58:29.037666Z,"Search for Drug",14
+2025-08-08T17:58:29.069614Z,"Save Drug Order",1745
+2025-08-08T17:58:29.824006Z,"Submit Visit Form",1235
+2025-08-08T17:58:29.875134Z,"Get Current Visit of Patient",94020
+2025-08-08T17:58:29.902080Z,"Get Visits of Patient",49445
+2025-08-08T17:58:30.480043Z,"Get Visit Types",1097
+2025-08-08T17:58:30.490878Z,"Get Locations That Support Visits",2180
+2025-08-08T17:58:30.499981Z,"Get Program Enrollments of Patient",14
+2025-08-08T17:58:30.508324Z,"Get Locations by Tag and Query",10661
+2025-08-08T17:58:30.511566Z,"Get Appointments of a Patient",2
+2025-08-08T17:58:30.523823Z,"Submit Visit Form",1236
+2025-08-08T17:58:30.528811Z,"Get patient identification photo",14
+2025-08-08T17:58:30.531883Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:30.537474Z,"Get Patient Summary Data",1183
+2025-08-08T17:58:30.545057Z,"Get Active Visits of Patient",582
+2025-08-08T17:58:30.550867Z,"Get Queue Entry",29
+2025-08-08T17:58:30.553283Z,"Get the status of patient death",49
+2025-08-08T17:58:30.554133Z,"Get queue entry number",97
+2025-08-08T17:58:30.571221Z,"Submit visit queue entry",7807
+2025-08-08T17:58:30.581001Z,"Get Queue Entry",8944
+2025-08-08T17:58:30.973995Z,"Search for Condition",107
+2025-08-08T17:58:31.027042Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:31.033044Z,"Get patient admission note",14
+2025-08-08T17:58:31.037338Z,"Get Beds for Patient",0
+2025-08-08T17:58:31.054374Z,"Save Ward Encounter",1765
+2025-08-08T17:58:31.196122Z,"Save Vitals",3200
+2025-08-08T17:58:31.992242Z,"Search for Condition",14
+2025-08-08T17:58:33.017103Z,"Save Conditions",1068
+2025-08-08T17:58:33.431423Z,"Get Programs",11948
+2025-08-08T17:58:33.448221Z,"Get Program Enrollments of Patient",0
+2025-08-08T17:58:33.590441Z,"Get service concept set",48
+2025-08-08T17:58:33.603053Z,"Get Concept",7419
+2025-08-08T17:58:33.622403Z,"Submit new Service queue",2208
+2025-08-08T17:58:34.086988Z,"Get Locations by Tag and Query",10667
+2025-08-08T17:58:34.126431Z,"Get medication request encounters",3555
+2025-08-08T17:58:34.130147Z,"Get patient age",10
+2025-08-08T17:58:34.133219Z,"Get patient age",0
+2025-08-08T17:58:34.921665Z,"Get Active Visits of Patient",581
+2025-08-08T17:58:34.932956Z,"Get Specific Visit Details",567
+2025-08-08T17:58:34.937037Z,"Get the details of a orderType",533
+2025-08-08T17:58:34.949715Z,"Get all Lab order details",28680
+2025-08-08T17:58:34.951606Z,"Get Module Information",0
+2025-08-08T17:58:34.969914Z,"Add a lab order",1716
+2025-08-08T17:58:36.087030Z,"Save Ward Encounter",1765
+2025-08-08T17:58:36.131381Z,"End Visit",2395
+2025-08-08T17:58:36.212476Z,"Get Allergies of Patient",17234
+2025-08-08T17:58:36.240720Z,"Get Drug Allergens",118868
+2025-08-08T17:58:36.261486Z,"Get Environment Allergens",93956
+2025-08-08T17:58:36.268383Z,"Get Food Allergens",28759
+2025-08-08T17:58:36.275598Z,"Get Allergic Reactions Allergens",45987
+2025-08-08T17:58:36.670753Z,"Submit transition request",1675
+2025-08-08T17:58:36.690222Z,"Get Queue Entry",18974
+2025-08-08T17:58:36.711560Z,"End Visit",1262
+2025-08-08T17:58:36.722286Z,"Get Current Visit of Patient",11317
+2025-08-08T17:58:36.735252Z,"Get Visits of Patient",21678
+2025-08-08T17:58:37.141176Z,"Get Patient Allergy Intolerance",448
+2025-08-08T17:58:37.176685Z,"Get Specific Medication Requests",3568
+2025-08-08T17:58:37.183196Z,"Get Encounter With Visit and Diagnoses",210
+2025-08-08T17:58:37.188247Z,"Get All Providers",1359
+2025-08-08T17:58:37.204549Z,"Get Patient Conditions",12291
+2025-08-08T17:58:38.475001Z,"Get Program Enrollments of Patient",0
+2025-08-08T17:58:38.487918Z,"Get Programs",0
+2025-08-08T17:58:38.507107Z,"Get locations",41279
+2025-08-08T17:58:38.512115Z,"Get Locations by Tag and Query",10667
+2025-08-08T17:58:38.522389Z,"Add new program to patient",2191
+2025-08-08T17:58:39.998213Z,"Get all active Lab orders",1329
+2025-08-08T17:58:40.005220Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:40.075672Z,"Get Lab Orders by full filler status",31538
+2025-08-08T17:58:40.078943Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:40.213593Z,"Get Patient Summary Data",1181
+2025-08-08T17:58:40.233831Z,"Get Order Entry Config",26242
+2025-08-08T17:58:40.246050Z,"Get ValueSet by UUID",1660
+2025-08-08T17:58:40.254687Z,"Get ValueSet by UUID",1285
+2025-08-08T17:58:40.271732Z,"Get Medication Request by UUID",1742
+2025-08-08T17:58:40.273957Z,"Get Medication by UUID",879
+2025-08-08T17:58:40.276772Z,"Get All Providers",0
+2025-08-08T17:58:40.279572Z,"Search Medication by Code",4395
+2025-08-08T17:58:40.298120Z,"Get Specific Medication Requests",3568
+2025-08-08T17:58:40.301146Z,"Get patient identification photo",14
+2025-08-08T17:58:40.303159Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:40.307595Z,"Get Active Visits of Patient",1209
+2025-08-08T17:58:40.311529Z,"Get Visit Queue Entry",0
+2025-08-08T17:58:40.313628Z,"Get the status of patient death",49
+2025-08-08T17:58:40.548717Z,"Complete the program",2217
+2025-08-08T17:58:40.563495Z,"Get Program Enrollments of Patient",14314
+2025-08-08T17:58:41.311525Z,"Save an Allergy",1532
+2025-08-08T17:58:43.082015Z,"Get Immunizations of Patient",11648
+2025-08-08T17:58:43.087828Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:43.092461Z,"Get Specific Visit Details",0
+2025-08-08T17:58:45.105217Z,"Update full filler status",0
+2025-08-08T17:58:45.119878Z,"Get all active Lab orders",1336
+2025-08-08T17:58:45.130854Z,"Get Lab Orders by full filler status",1336
+2025-08-08T17:58:45.189216Z,"Get Lab Orders by full filler status",31538
+2025-08-08T17:58:45.192068Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:45.357818Z,"Dispense medication form submission",1952
+2025-08-08T17:58:45.397496Z,"Get medication request encounters",5626
+2025-08-08T17:58:45.414341Z,"Get Medication Request by UUID",0
+2025-08-08T17:58:45.446326Z,"Get Specific Medication Requests",5639
+2025-08-08T17:58:45.861728Z,"Upload Attachment Request",115
+2025-08-08T17:58:45.868047Z,"Get Attachments of Patient",1108
+2025-08-08T17:58:48.113398Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:48.125189Z,"Get Specific Visit Details",0
+2025-08-08T17:58:48.169262Z,"Get Immunizations of Patient",11648
+2025-08-08T17:58:48.174837Z,"Get all immunizations",2244
+2025-08-08T17:58:48.464898Z,"Get Patient Summary Data",0
+2025-08-08T17:58:48.484184Z,"Get ValueSet by UUID",2315
+2025-08-08T17:58:48.490756Z,"Get patient identification photo",0
+2025-08-08T17:58:48.494579Z,"Get Primary Identifier Term Mapping",0
+2025-08-08T17:58:48.502352Z,"Get Active Visits of Patient",0
+2025-08-08T17:58:48.505444Z,"Get the status of patient death",0
+2025-08-08T17:58:50.211008Z,"Get specific encounter details",794
+2025-08-08T17:58:50.217995Z,"Get Alkaline concept details",1387
+2025-08-08T17:58:50.250301Z,"Update the specific encounter",1931
+2025-08-08T17:58:50.264526Z,"Update the Lab Order Completion",2774
+2025-08-08T17:58:50.270362Z,"Update full filler status",0
+2025-08-08T17:58:50.272972Z,"Get all active Lab orders",14
+2025-08-08T17:58:50.275465Z,"Get Lab Orders by full filler status",14
+2025-08-08T17:58:50.326037Z,"Get Lab Orders by full filler status",32905
+2025-08-08T17:58:50.328901Z,"Get Lab Orders by full filler status",0
+2025-08-08T17:58:50.877776Z,"Get Appointments of a Patient",2
+2025-08-08T17:58:51.537465Z,"Close medication",1415
+2025-08-08T17:58:51.586680Z,"Get medication request encounters",7160
+2025-08-08T17:58:51.605349Z,"Get Medication Request by UUID",0
+2025-08-08T17:58:51.641441Z,"Get Specific Medication Requests",7173
+2025-08-08T17:58:51.654516Z,"Discontinue the drug order",3275
+2025-08-08T17:58:51.671093Z,"End Visit",1481
+2025-08-08T17:58:51.701943Z,"Get Current Visit of Patient",105437
+2025-08-08T17:58:51.733352Z,"Get Visits of Patient",115798
+2025-08-08T17:58:53.229882Z,"Submit Patient immunization",1131
+2025-08-08T17:58:53.232798Z,"Get Immunizations of Patient",442
+2025-08-08T17:58:55.376369Z,"End Visit",1481
+2025-08-08T17:58:55.418591Z,"Get Current Visit of Patient",114732
+2025-08-08T17:58:55.446149Z,"Get Visits of Patient",56423
+2025-08-08T17:58:55.912041Z,"Save Visit Note",1768
+2025-08-08T17:58:55.924026Z,"Save Patient Diagnosis",1229
+2025-08-08T17:58:55.931492Z,"Save Patient Diagnosis",1293
+2025-08-08T17:58:58.267370Z,"Get Attachments of Patient",3298
+2025-08-08T17:58:58.271849Z,"Get Allowed File Extensions",42
+2025-08-08T17:59:03.295516Z,"Get Programs",11948
+2025-08-08T17:59:03.321366Z,"Get Program Enrollments of Patient",0
+2025-08-08T17:59:05.982308Z,"End Visit",1492
+2025-08-08T17:59:06.056612Z,"Get Current Visit of Patient",289059
+2025-08-08T17:59:06.089150Z,"Get Visits of Patient",75564
+2025-08-08T17:59:08.354169Z,"Get Program Enrollments of Patient",0
+2025-08-08T17:59:08.363058Z,"Get Programs",0
+2025-08-08T17:59:08.385596Z,"Get locations",41279
+2025-08-08T17:59:08.389808Z,"Get Locations by Tag and Query",10667
+2025-08-08T17:59:08.397809Z,"Add new program to patient",2191
+2025-08-08T17:59:10.423353Z,"Complete the program",2217
+2025-08-08T17:59:10.448077Z,"Get Program Enrollments of Patient",47683
+2025-08-08T17:59:15.773850Z,"Upload Attachment Request",115
+2025-08-08T17:59:15.784542Z,"Get Attachments of Patient",3663
+2025-08-08T17:59:20.805831Z,"Get Appointments of a Patient",1147
+2025-08-08T17:59:25.847705Z,"Save Visit Note",1768
+2025-08-08T17:59:25.857995Z,"Save Patient Diagnosis",1229
+2025-08-08T17:59:25.864918Z,"Save Patient Diagnosis",1293
+2025-08-08T17:59:35.912887Z,"End Visit",1492
+2025-08-08T17:59:36.054372Z,"Get Current Visit of Patient",1004562
+2025-08-08T17:59:36.078926Z,"Get Visits of Patient",33073

--- a/response-sizes/styles.css
+++ b/response-sizes/styles.css
@@ -1,0 +1,127 @@
+/* Dark Mode Color Palette */
+:root {
+    --bg-color: #212529;
+    --container-bg: #2c303a;
+    --text-color: #e9ecef;
+    --border-color: #495057;
+    --header-blue: #0d6efd; /* A modern, vibrant blue */
+    --row-alt-bg: #343a40;
+    --hover-bg: #495057;
+    --error-color: #f46a6a;
+}
+
+/* General Body and Font Styles */
+body {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    padding: 0;
+}
+
+/* Header Styling */
+header {
+    background-color: #1a1d20;
+    border-bottom: 1px solid var(--border-color);
+    padding: 20px 40px;
+}
+
+header h1 {
+    margin: 0;
+    font-weight: 300;
+    font-size: 1.5em;
+}
+
+/* Main Content Area */
+main {
+    max-width: 1200px;
+    margin: 20px auto;
+    padding: 20px;
+    background-color: var(--container-bg);
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+}
+
+/* Table Styling - Dark Gatling */
+#reportContainer table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+    font-size: 14px;
+}
+
+#reportContainer th, #reportContainer td {
+    border: 1px solid var(--border-color);
+    padding: 12px;
+    text-align: left;
+}
+
+#reportContainer th {
+    background-color: var(--header-blue);
+    color: white;
+    font-weight: 600;
+}
+
+#reportContainer tr:nth-child(even) {
+    background-color: var(--row-alt-bg);
+}
+
+#reportContainer tr:hover {
+    background-color: var(--hover-bg);
+}
+
+/* Status Messages */
+#loadingMessage {
+    color: #888;
+}
+
+.error-message {
+    color: var(--error-color);
+    background-color: rgba(244, 106, 106, 0.1);
+    border: 1px solid var(--error-color);
+    padding: 15px;
+    border-radius: 4px;
+}
+
+/* Utility classes for text alignment */
+.text-left {
+    text-align: left;
+}
+
+.text-right {
+    text-align: right;
+    font-family: 'Menlo', 'Monaco', monospace;
+}
+
+/* Add this to your styles.css file */
+
+/* Style for column headers that can be sorted */
+#reportContainer th.sortable {
+    cursor: pointer;
+    position: relative;
+    padding-right: 30px; /* Make a little more space for the arrows */
+}
+
+/* Default up/down arrow (unsorted) */
+#reportContainer th.sortable::after {
+    /* BEFORE: content: ' \2195'; */
+    content: '\25B2\25BC'; /* AFTER: Separate up (▲) and down (▼) triangles */
+    position: absolute;
+    right: 10px;
+    font-size: 0.8em; /* Make the default icons a bit smaller */
+    color: #6c757d;   /* A fainter color for the inactive state */
+}
+
+/* Up arrow for ascending sort */
+#reportContainer th.sorted-asc::after {
+    content: ' \25B2'; /* Unicode for up triangle */
+    font-size: 0.9em;
+    color: #fff;
+}
+
+/* Down arrow for descending sort */
+#reportContainer th.sorted-desc::after {
+    content: ' \25BC'; /* Unicode for down triangle */
+    font-size: 0.9em;
+    color: #fff;
+}

--- a/src/test/java/org/openmrs/performance/simulations/OpenMRSClinic.java
+++ b/src/test/java/org/openmrs/performance/simulations/OpenMRSClinic.java
@@ -13,6 +13,7 @@ import org.openmrs.performance.personas.LabTechPersona;
 import org.openmrs.performance.personas.Persona;
 import org.openmrs.performance.personas.PharmacistPersona;
 import org.openmrs.performance.scenarios.Scenario;
+import org.openmrs.performance.utils.ResponseSizeLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,7 +22,6 @@ import java.util.List;
 
 import static io.gatling.javaapi.core.CoreDsl.constantConcurrentUsers;
 import static io.gatling.javaapi.core.CoreDsl.forAll;
-import static io.gatling.javaapi.core.CoreDsl.global;
 import static io.gatling.javaapi.core.CoreDsl.rampConcurrentUsers;
 import static io.gatling.javaapi.http.HttpDsl.http;
 import static org.openmrs.performance.Constants.ENV_SIMULATION_PRESET;
@@ -105,6 +105,17 @@ public class OpenMRSClinic extends Simulation {
 		return http.baseUrl(org.openmrs.performance.Constants.BASE_URL).acceptHeader("application/json, text/plain, */*")
 		        .acceptLanguageHeader("en-US,en;q=0.5")
 		        .userAgentHeader("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0")
-		        .header("Authorization", "Bearer YWRtaW46QWRtaW4xMjM=").header("Content-Type", "application/json");
+		        .header("Authorization", "Bearer YWRtaW46QWRtaW4xMjM=").header("Content-Type", "application/json")
+		        .transformResponse((response, session) -> {
+			        if (response.body() != null) {
+				        ResponseSizeLogger.log(response.request().getName(), response.body().length());
+			        }
+			        return response;
+		        });
+	}
+
+	@Override
+	public void after() {
+		ResponseSizeLogger.close();
 	}
 }

--- a/src/test/java/org/openmrs/performance/utils/ResponseSizeLogger.java
+++ b/src/test/java/org/openmrs/performance/utils/ResponseSizeLogger.java
@@ -1,0 +1,50 @@
+package org.openmrs.performance.utils;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.Instant;
+
+public class ResponseSizeLogger {
+
+	private static final String LOG_FILE_PATH = System.getProperty("user.dir") + "/response-sizes/response_sizes.csv";
+
+	private static final PrintWriter writer;
+
+	static {
+		System.out.println("ResponseSizeLogger: CSV file will be created at: " + LOG_FILE_PATH);
+
+		try {
+			File logFile = new File(LOG_FILE_PATH);
+			File parentDir = logFile.getParentFile();
+
+			if (parentDir != null && !parentDir.exists()) {
+				if (!parentDir.mkdirs()) {
+					throw new IOException("Failed to create parent directory: " + parentDir);
+				}
+			}
+
+			FileWriter fileWriter = new FileWriter(logFile, false);
+			writer = new PrintWriter(fileWriter);
+
+			writer.println("Timestamp,RequestName,ResponseSize(Bytes)");
+
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to initialize ResponseSizeLogger.", e);
+		}
+	}
+
+	public static synchronized void log(String requestName, int responseSize) {
+		writer.println(Instant.now() + ",\"" + requestName + "\"," + responseSize);
+	}
+
+	public static void close() {
+		if (writer != null) {
+			System.out.println("Closing ResponseSizeLogger CSV writer.");
+			writer.flush();
+			writer.close();
+		}
+	}
+}


### PR DESCRIPTION
When conducting performance testing, the size of the response payload plays a crucial role in observing and monitoring the performance of endpoints. Large or unusually small response sizes can significantly impact performance and may contribute to delayed responses or other performance issues.

 

This JIRA aims to introduce a feature that generates a table summarizing response sizes for each request. The table will include key statistical metrics such as:

 

Mean

Median

Maximum

Minimum

75th percentile

90th percentile

99th percentile

 

By having this data readily available, it will be easier to identify patterns, anomalies, and potential root causes of performance degradation. This enhancement will provide better insights during performance analysis and help in fine-tuning endpoint efficiency.

Ticket: https://openmrs.atlassian.net/browse/O3-4953