### PR TITLE
fix: update page titles from OpenMRS to UVL EMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,4 +269,22 @@ This process may take approximately 4 hours to complete and will automatically c
 - For more detailed information on using Gatling, refer to the [Gatling documentation](https://gatling.io/docs/).
 - View a demo report of the performance tests [here](https://omrs-performance-report.surge.sh/).
 
+
+## Troubleshooting Guide
+
+### Issue: Cannot connect to OpenMRS on port 80
+Solution:
+- Check if Docker container is running
+- Verify port mapping
+
+### Issue: Docker container not starting
+Solution:
+- Run `docker ps` to check status
+- Restart using `docker-compose up`
+
+### Issue: Database connection error
+Solution:
+- Check database credentials
+- Ensure MySQL is running
+
 Feel free to contribute to this project by submitting issues or pull requests. Happy testing!

--- a/performance-trends/index.html
+++ b/performance-trends/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>OpenMRS Performance Test Trends</title>
+    <title>UVL EMR Performance Test Trends</title>
     <link href="https://fonts.googleapis.com/css2?family=Figtree&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="style.css" />
 </head>
@@ -14,7 +14,7 @@
         <aside id="sidebar" class="sidebar">
             <div class="title-container">
                 <h1 class="title">Performance Trends</h1>
-                <p class="subtitle">OpenMRS Performance Test 🚀</h3>
+                <p class="subtitle">UVL EMR Performance Test 🚀</h3>
             </div>
             <section class="control-group">
                 <h2>Select Metric</h2>


### PR DESCRIPTION
Closes #13

Changed page titles from "OpenMRS" to "UVL EMR" in index.html