### PR TITLE
Add troubleshooting guide for common issues

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,23 @@
+# Troubleshooting Guide
+
+## 1. OpenMRS connection issues (Port 80)
+If OpenMRS is not accessible:
+- Check if port 80 is already in use
+- Stop the conflicting process
+- Or change the port
+
+## 2. Docker issues
+If Docker is not working:
+- Ensure Docker is installed
+- Start Docker before running the project
+- Check Docker permissions
+
+## 3. Maven build issues
+If build fails:
+- Run: mvn clean install
+- Check Java version compatibility
+
+## 4. Gatling test failures
+If tests fail:
+- Check logs for errors
+- Ensure all dependencies are installed


### PR DESCRIPTION
This PR adds a troubleshooting guide to help developers solve common setup issues such as:

- OpenMRS connection errors (Port 80)
- Docker setup issues
- Maven build failures
- Gatling test failures

This will improve developer onboarding and reduce repeated issues.